### PR TITLE
Piggy backing

### DIFF
--- a/protocols/gossipsub/src/layer.rs
+++ b/protocols/gossipsub/src/layer.rs
@@ -757,7 +757,7 @@ impl<TSubstream> Gossipsub<TSubstream> {
         }
 
         // piggyback pooled control messages
-        flush_control_pool();
+        self.flush_control_pool();
 
         // shift the memcache
         self.mcache.shift();
@@ -923,13 +923,11 @@ impl<TSubstream> Gossipsub<TSubstream> {
 
     // adds a control action to control_pool
     fn control_pool_add(&mut self, peer: PeerId, control: GossipsubControlAction) {
-        if !self.control_pool.contains_key(&peer) {
-            self.control_pool.insert(peer.clone(), Vec::new());
-        }
-
-        if let Some(controls) = self.control_pool.get_mut(&peer) {
-            controls.push(control.clone());
-        }
+        (*self
+            .control_pool
+            .entry(peer.clone())
+            .or_insert_with(|| Vec::new()))
+        .push(control.clone());
     }
 
     // takes each control action mapping and turns it into a message

--- a/protocols/gossipsub/src/layer/tests.rs
+++ b/protocols/gossipsub/src/layer/tests.rs
@@ -647,4 +647,18 @@ mod tests {
             "Expected event count to stay the same"
         )
     }
+
+    #[test]
+    // tests that a peer is removed from our mesh
+    fn test_handle_prune_in_mesh(){
+        let (mut gs, peers, topic_hashes) =
+            build_and_inject_nodes(20, vec![String::from("topic1")], true);
+
+        // insert peer into our mesh for 'topic1'
+        gs.mesh.insert(topic_hashes[0].clone(), peers.clone());
+        assert!(gs.mesh.get(&topic_hashes[0]).unwrap().contains(&peers[7]));
+
+        gs.handle_prune(&peers[7], topic_hashes.clone());
+        assert!(!gs.mesh.get(&topic_hashes[0]).unwrap().contains(&peers[7]));
+    }
 }

--- a/protocols/gossipsub/src/layer/tests.rs
+++ b/protocols/gossipsub/src/layer/tests.rs
@@ -649,16 +649,65 @@ mod tests {
     }
 
     #[test]
+    // tests that a peer is added to our mesh when we are both subscribed
+    // to the same topic
+    fn test_handle_graft_is_subscribed() {
+        let (mut gs, peers, topic_hashes) =
+            build_and_inject_nodes(20, vec![String::from("topic1")], true);
+
+        assert!(
+            !gs.mesh.get(&topic_hashes[0]).unwrap().contains(&peers[7]),
+            "Expected peer to not be in mesh"
+        );
+
+        gs.handle_graft(&peers[7], topic_hashes.clone());
+
+        assert!(
+            gs.mesh.get(&topic_hashes[0]).unwrap().contains(&peers[7]),
+            "Expected peer to have been added to mesh"
+        );
+    }
+
+    #[test]
+    // tests that a peer is not added to our mesh when they are subscribed to
+    // a topic that we are not
+    fn test_handle_graft_is_not_subscribed() {
+        let (mut gs, peers, topic_hashes) =
+            build_and_inject_nodes(20, vec![String::from("topic1")], true);
+
+        assert!(
+            !gs.mesh.get(&topic_hashes[0]).unwrap().contains(&peers[7]),
+            "Expected peer to not be in mesh"
+        );
+
+        gs.handle_graft(
+            &peers[7],
+            vec![TopicHash::from_raw(String::from("unsubscribed topic"))]
+        );
+
+        assert!(
+            !gs.mesh.get(&topic_hashes[0]).unwrap().contains(&peers[7]),
+            "Expected peer to have been added to mesh"
+        );
+    }
+
+    #[test]
     // tests that a peer is removed from our mesh
-    fn test_handle_prune_in_mesh(){
+    fn test_handle_prune_peer_in_mesh(){
         let (mut gs, peers, topic_hashes) =
             build_and_inject_nodes(20, vec![String::from("topic1")], true);
 
         // insert peer into our mesh for 'topic1'
         gs.mesh.insert(topic_hashes[0].clone(), peers.clone());
-        assert!(gs.mesh.get(&topic_hashes[0]).unwrap().contains(&peers[7]));
+        assert!(
+            gs.mesh.get(&topic_hashes[0]).unwrap().contains(&peers[7]),
+            "Expected peer to be in mesh"
+        );
 
         gs.handle_prune(&peers[7], topic_hashes.clone());
-        assert!(!gs.mesh.get(&topic_hashes[0]).unwrap().contains(&peers[7]));
+        assert!(
+            !gs.mesh.get(&topic_hashes[0]).unwrap().contains(&peers[7]),
+            "Expected peer to be removed from mesh"
+        );
     }
 }


### PR DESCRIPTION
The piggybacking mechanism implemented here pools control messages between heartbeats and then coalesces them into `NetworkBehaviourAction::SendEvent` objects before adding them to the `events` queue.

This differs from the Go implementation as I understand it, but should still achieve the desired result of reducing network congestion.

There are also some tests that I wrote a while back in this PR around grafts and prunes.