### PR TITLE
Update enr crate to latest spec

### DIFF
--- a/misc/enr/Cargo.toml
+++ b/misc/enr/Cargo.toml
@@ -15,7 +15,6 @@ bs58 = "0.2.2"
 base64 = "0.10.1"
 rand = "0.6.5"
 hex = "0.3.2"
-indexmap = "1.0.2"
 serde = { version = "1.0.93", optional = true }
 
 [dev-dependencies]

--- a/misc/enr/src/lib.rs
+++ b/misc/enr/src/lib.rs
@@ -136,7 +136,6 @@ impl Enr {
     }
 
     /// Returns the IPv4 address of the ENR record if it is defined.
-    /// TODO: check if need to return Ipv4Addr instead of IpAddr.
     pub fn ip(&self) -> Option<Ipv4Addr> {
         if let Some(ip_bytes) = self.content.get("ip") {
             return match ip_bytes.len() {
@@ -152,7 +151,6 @@ impl Enr {
     }
 
     /// Returns the IPv6 address of the ENR record if it is defined.
-    /// TODO: check if need to return Ipv6Addr instead of IpAddr.
     pub fn ip6(&self) -> Option<Ipv6Addr> {
         if let Some(ip_bytes) = self.content.get("ip6") {
             return match ip_bytes.len() {

--- a/misc/enr/src/lib.rs
+++ b/misc/enr/src/lib.rs
@@ -45,10 +45,10 @@ mod node_id;
 
 use crate::enr_keypair::{EnrKeypair, EnrPublicKey};
 use base64;
-use indexmap::IndexMap;
 use libp2p_core::identity::{ed25519, Keypair, PublicKey};
 use log::debug;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use std::collections::BTreeMap;
 
 #[cfg(feature = "serde")]
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
@@ -76,9 +76,9 @@ pub struct Enr {
     /// The `NodeId` of the ENR record.
     node_id: NodeId,
 
-    /// Key-value contents of the ENR. An IndexMap is used to preserve the order of keys, which is
+    /// Key-value contents of the ENR. A BTreeMap is used to get the keys in sorted order, which is
     /// important for verifying the signature of the ENR.
-    content: IndexMap<String, Vec<u8>>,
+    content: BTreeMap<String, Vec<u8>>,
 
     /// The signature of the ENR record, stored as bytes.
     signature: Vec<u8>,
@@ -498,7 +498,7 @@ pub struct EnrBuilder {
     seq: u64,
 
     /// The key-value pairs for the ENR record.
-    content: IndexMap<String, Vec<u8>>,
+    content: BTreeMap<String, Vec<u8>>,
 }
 
 impl EnrBuilder {
@@ -506,7 +506,7 @@ impl EnrBuilder {
     pub fn new() -> Self {
         EnrBuilder {
             seq: 1,
-            content: IndexMap::new(),
+            content: BTreeMap::new(),
         }
     }
 
@@ -656,7 +656,7 @@ impl Decodable for Enr {
         seq[8 - seq_bytes.len()..].copy_from_slice(&seq_bytes);
         let seq = u64::from_be_bytes(seq);
 
-        let mut content = IndexMap::new();
+        let mut content = BTreeMap::new();
         for _ in 0..decoded_list.len() / 2 {
             let key = decoded_list.remove(0);
             let value = decoded_list.remove(0);

--- a/misc/enr/src/lib.rs
+++ b/misc/enr/src/lib.rs
@@ -743,6 +743,32 @@ mod tests {
     }
 
     #[test]
+    fn check_test_vector_2() {
+        let text = "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
+        let signature = hex::decode("7098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f30813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c").unwrap();
+        let expected_pubkey =
+            hex::decode("03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138")
+                .unwrap();
+
+        let enr: Enr = Enr::from_str(text).unwrap();
+        let pubkey = match enr.public_key() {
+            PublicKey::Secp256k1(key) => Some(key.encode()),
+            _ => None,
+        };
+
+        assert_eq!(enr.ip(), Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        assert_eq!(enr.ip6(), None);
+        assert_eq!(enr.id(), Some(String::from("v4")));
+        assert_eq!(enr.udp(), Some(30303));
+        assert_eq!(enr.udp6(), None);
+        assert_eq!(enr.tcp(), None);
+        assert_eq!(enr.tcp6(), None);
+        assert_eq!(enr.signature(), &signature[..]);
+        assert_eq!(pubkey.unwrap().to_vec(), expected_pubkey);
+        assert!(enr.verify());
+    }
+
+    #[test]
     fn test_encode_decode_secp256k1() {
         let key = Keypair::generate_secp256k1();
 

--- a/misc/enr/src/lib.rs
+++ b/misc/enr/src/lib.rs
@@ -280,10 +280,11 @@ impl Enr {
         s.drain()
     }
 
-    /// Provides the URL-safe base64 encoded "text" version of the ENR.
+    /// Provides the URL-safe base64 encoded "text" version of the ENR prefixed by "enr:".
     pub fn to_base64(&self) -> String {
         let cloned_self = self.clone();
-        base64::encode_config(&cloned_self.encode(), base64::URL_SAFE)
+        let hex = base64::encode_config(&cloned_self.encode(), base64::URL_SAFE);
+        format!("enr:{}", hex)
     }
 
     /// Returns the current size of the ENR.
@@ -456,7 +457,7 @@ impl std::fmt::Display for Enr {
 
 impl std::fmt::Debug for Enr {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "ENR: {}", self.to_base64())
+        write!(f, "{}", self.to_base64())
     }
 }
 
@@ -465,6 +466,7 @@ impl FromStr for Enr {
     type Err = String;
 
     fn from_str(base64_string: &str) -> Result<Self, Self::Err> {
+        let base64_string = base64_string.split_at(4).1;
         let bytes = base64::decode_config(base64_string, base64::URL_SAFE)
             .map_err(|_| "Invalid base64 encoding")?;
         rlp::decode::<Enr>(&bytes).map_err(|e| format!("Invalid ENR: {:?}", e))


### PR DESCRIPTION
Update enr to latest spec from [here](https://eips.ethereum.org/EIPS/eip-778). 

## Changes

- Change content map from `IndexMap` to `BTreeMap` to get sorted keys.
- Add `ip6`, `tcp6` and `udp6` keys to content map.
- Fix encoding.
- Add test vector from spec