### PR TITLE
Update the DHT on received ping

### DIFF
--- a/misc/discv5/src/behaviour.rs
+++ b/misc/discv5/src/behaviour.rs
@@ -329,11 +329,7 @@ impl<TSubstream> Discv5<TSubstream> {
                                 let req = rpc::Request::FindNode { distance: 0 };
                                 self.send_rpc_request(&node_id, req, None);
                             }
-                            self.connection_updated(
-                                node_id.clone(),
-                                Some(enr),
-                                NodeStatus::Connected,
-                            )
+                            self.connection_updated(node_id.clone(), None, NodeStatus::Connected)
                         }
                         None => (),
                     }

--- a/misc/discv5/src/behaviour.rs
+++ b/misc/discv5/src/behaviour.rs
@@ -930,3 +930,56 @@ pub enum Discv5Event {
         closer_peers: Vec<PeerId>,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enr::EnrBuilder;
+    use libp2p_core::identity;
+
+    #[test]
+    fn test_updating_connection_on_ping() {
+        let keypair = identity::Keypair::generate_secp256k1();
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+        let enr = EnrBuilder::new("v4")
+            .ip(ip.clone().into())
+            .udp(10001)
+            .build(&keypair)
+            .unwrap();
+        let ip2: IpAddr = "127.0.0.1".parse().unwrap();
+        let keypair2 = identity::Keypair::generate_secp256k1();
+        let enr2 = EnrBuilder::new("v4")
+            .ip(ip2.clone().into())
+            .udp(10002)
+            .build(&keypair2)
+            .unwrap();
+
+        // Set up discv5 with one disconnected node
+        let mut discv5: Discv5<Box<u64>> = Discv5::new(enr, keypair.clone(), ip.into()).unwrap();
+        discv5.add_enr(enr2.clone());
+        discv5.connection_updated(enr2.node_id().clone(), None, NodeStatus::Disconnected);
+
+        let mut buckets = discv5.kbuckets.clone();
+        let mut node = buckets.iter().next().unwrap();
+        assert_eq!(node.status, NodeStatus::Disconnected);
+
+        // Add a fake request
+        let ping_response = rpc::Response::Ping {
+            enr_seq: 2,
+            ip: ip2,
+            port: 10002,
+        };
+        let ping_request = rpc::Request::Ping { enr_seq: 2 };
+        let req = RpcRequest(2, enr2.node_id().clone());
+        discv5
+            .active_rpc_requests
+            .insert(req, (Some(1), ping_request.clone()));
+
+        // Handle the ping and expect the disconnected Node to become connected
+        discv5.handle_rpc_response(enr2.node_id().clone(), 2, ping_response);
+        buckets = discv5.kbuckets.clone();
+
+        node = buckets.iter().next().unwrap();
+        assert_eq!(node.status, NodeStatus::Connected);
+    }
+}

--- a/misc/discv5/src/behaviour/test.rs
+++ b/misc/discv5/src/behaviour/test.rs
@@ -3,15 +3,10 @@
 use crate::{Discv5, Discv5Event};
 use env_logger;
 use libp2p_core::{
-    identity,
-    Transport,
-    muxing::StreamMuxerBox,
-    nodes::Substream,
-    PeerId,
-    transport::MemoryTransport,
-    transport::boxed::Boxed,
+    identity, muxing::StreamMuxerBox, nodes::Substream, transport::boxed::Boxed,
+    transport::MemoryTransport, PeerId, Transport,
 };
-use libp2p_swarm::{Swarm};
+use libp2p_swarm::Swarm;
 use tokio::prelude::*;
 
 use crate::kbucket;
@@ -21,9 +16,8 @@ use libp2p_secio::SecioConfig;
 use libp2p_yamux as yamux;
 use std::io;
 use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use std::sync::{Arc,Mutex};
-
 
 type SwarmType =
     Swarm<Boxed<(PeerId, StreamMuxerBox), io::Error>, Discv5<Substream<StreamMuxerBox>>>;
@@ -32,9 +26,7 @@ fn init() {
     let _ = env_logger::builder().is_test(true).try_init();
 }
 
-fn build_swarms(n: usize) -> 
-Vec<SwarmType> 
- {
+fn build_swarms(n: usize) -> Vec<SwarmType> {
     let base_port = 10000u16;
     let mut swarms = Vec::new();
     let ip: IpAddr = "127.0.0.1".parse().unwrap();
@@ -101,7 +93,8 @@ fn test_findnode_query() {
     let test_result = Arc::new(Mutex::new(true));
     let thread_result = test_result.clone();
 
-    tokio::run(future::poll_fn(move || -> Result<_, io::Error> {
+    tokio::run(
+        future::poll_fn(move || -> Result<_, io::Error> {
             for swarm in swarms.iter_mut() {
                 loop {
                     match swarm.poll().unwrap() {
@@ -124,10 +117,11 @@ fn test_findnode_query() {
                 }
             }
             Ok(Async::NotReady)
-        }).timeout(Duration::from_millis(500))
-            .map_err(move |_| 
-                     *thread_result.lock().unwrap() = false)
-            .map(|_| ()));
+        })
+        .timeout(Duration::from_millis(500))
+        .map_err(move |_| *thread_result.lock().unwrap() = false)
+        .map(|_| ()),
+    );
 
     assert!(*test_result.lock().unwrap());
 }


### PR DESCRIPTION
I have a few questions on this: 
- Should the `connection_updated` also be called when ENR sequence that was received? Or will this be done when the requested new ENR is returned?
- Could it happen that a PING is received for which no ENR can be found?
