### PR TITLE
Add reference tests

### DIFF
--- a/misc/discv5/src/packet/mod.rs
+++ b/misc/discv5/src/packet/mod.rs
@@ -349,20 +349,83 @@ mod tests {
 
     #[test]
     fn ref_test_encode_random_packet() {
-
         // reference input
-        let tag = [1u8;TAG_LENGTH]; // all 1's.
+        let tag = [1u8; TAG_LENGTH]; // all 1's.
         let auth_tag = [2u8; AUTH_TAG_LENGTH]; // all 2's
-        let random_data =  [4u8; 44]; // 44 bytes of 4's;
+        let random_data = [4u8; 44]; // 44 bytes of 4's;
 
         // expected hex output
         let expected_output = hex::decode("01010101010101010101010101010101010101010101010101010101010101018c0202020202020202020202020404040404040404040404040404040404040404040404040404040404040404040404040404040404040404").unwrap();
-        
 
         let packet = Packet::RandomPacket {
             tag,
             auth_tag,
             data: random_data.to_vec(),
+        };
+
+        assert_eq!(packet.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_whoareyou_packet() {
+        // reference input
+        let magic = [1u8; MAGIC_LENGTH]; // all 1's.
+        let token = [2u8; AUTH_TAG_LENGTH]; // all 2's
+        let id_nonce = [3u8; ID_NONCE_LENGTH]; // all 3's
+        let enr_seq = 1;
+
+        // expected hex output
+        let expected_output = hex::decode("0101010101010101010101010101010101010101010101010101010101010101ef8c020202020202020202020202a0030303030303030303030303030303030303030303030303030303030303030301").unwrap();
+
+        let packet = Packet::WhoAreYou {
+            magic,
+            token,
+            id_nonce,
+            enr_seq,
+        };
+
+        assert_eq!(packet.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_auth_message_packet() {
+        // reference input
+        let tag = [1u8; TAG_LENGTH]; // all 1's.
+        let auth_header = AuthHeader::new(
+            [2; AUTH_TAG_LENGTH], // all 2's
+            [3; ID_NONCE_LENGTH], // all 3's
+            [4; 64].to_vec(),     // all 4's
+            [5; 42].to_vec(),     // all 5's
+        );
+
+        let random_data = [6; 44].to_vec();
+
+        // expected hex output
+        let expected_output = hex::decode("0101010101010101010101010101010101010101010101010101010101010101f89f8c020202020202020202020202a003030303030303030303030303030303030303030303030303030303030303038367636db84004040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404aa0505050505050505050505050505050505050505050505050505050505050505050505050505050505050606060606060606060606060606060606060606060606060606060606060606060606060606060606060606").unwrap();
+
+        let packet = Packet::AuthMessage {
+            tag,
+            auth_header,
+            message: random_data,
+        };
+
+        assert_eq!(packet.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_message_packet() {
+        // reference input
+        let tag = [1u8; TAG_LENGTH]; // all 1's.
+        let auth_tag = [2; AUTH_TAG_LENGTH]; // all 2's
+        let random_data = [3; 44].to_vec();
+
+        // expected hex output
+        let expected_output = hex::decode("01010101010101010101010101010101010101010101010101010101010101018c0202020202020202020202020303030303030303030303030303030303030303030303030303030303030303030303030303030303030303").unwrap();
+
+        let packet = Packet::Message {
+            tag,
+            auth_tag,
+            message: random_data,
         };
 
         assert_eq!(packet.encode(), expected_output);
@@ -453,5 +516,4 @@ mod tests {
 
         assert_eq!(decoded_packet, packet);
     }
-
 }

--- a/misc/discv5/src/rpc.rs
+++ b/misc/discv5/src/rpc.rs
@@ -426,6 +426,165 @@ mod tests {
     use enr::EnrBuilder;
     use libp2p_core::identity::Keypair;
 
+     #[test]
+    fn ref_test_encode_request_ping() {
+        // reference input
+        let id = 1;
+        let enr_seq = 1;
+        let body = RpcType::Request(Request::Ping { enr_seq });
+
+        // expected hex output
+        let expected_output = hex::decode("01c20101").unwrap();
+
+        let protocol_msg = ProtocolMessage { id, body };
+
+        assert_eq!(protocol_msg.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_request_findnode() {
+        // reference input
+        let id = 1;
+        let distance = 256;
+        let body = RpcType::Request(Request::FindNode { distance });
+
+        // expected hex output
+        let expected_output = hex::decode("03c401820100").unwrap();
+
+        let protocol_msg = ProtocolMessage { id, body };
+
+        assert_eq!(protocol_msg.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_request_ticket() {
+        // reference input
+        let id = 1;
+        let topic_hash = [0; 32]; // all 0's
+        let body = RpcType::Request(Request::Ticket { topic: topic_hash });
+
+        // expected hex output
+        let expected_output =
+            hex::decode("05e201a00000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap();
+
+        let protocol_msg = ProtocolMessage { id, body };
+
+        assert_eq!(protocol_msg.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_request_register_topic() {
+        // reference input
+        let id = 1;
+        let ticket = [0; 32].to_vec(); // all 0's
+        let body = RpcType::Request(Request::RegisterTopic { ticket });
+
+        // expected hex output
+        let expected_output =
+            hex::decode("07e201a00000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap();
+
+        let protocol_msg = ProtocolMessage { id, body };
+
+        assert_eq!(protocol_msg.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_request_topic_query() {
+        // reference input
+        let id = 1;
+        let topic_hash = [0; 32]; // all 0's
+        let body = RpcType::Request(Request::TopicQuery { topic: topic_hash });
+
+        // expected hex output
+        let expected_output =
+            hex::decode("09e201a00000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap();
+
+        let protocol_msg = ProtocolMessage { id, body };
+
+        assert_eq!(protocol_msg.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_response_ping() {
+        // reference input
+        let id = 1;
+        let enr_seq = 1;
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+        let port = 5000;
+        let body = RpcType::Response(Response::Ping { enr_seq, ip, port });
+
+        // expected hex output
+        let expected_output = hex::decode("02ca0101847f000001821388").unwrap();
+
+        let protocol_msg = ProtocolMessage { id, body };
+
+        assert_eq!(protocol_msg.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_response_nodes() {
+        // reference input
+        let id = 1;
+        let total = 1;
+        // ENR needs to be constructed from a keypair
+        let secret_key = libp2p_core::identity::secp256k1::SecretKey::from_bytes(
+            hex::decode("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+                .unwrap(),
+        )
+        .unwrap();
+
+        let key = Keypair::Secp256k1(libp2p_core::identity::secp256k1::Keypair::from(secret_key));
+        let enr = EnrBuilder::new("v4").build(&key).unwrap();
+        let body = RpcType::Response(Response::Nodes {
+            total,
+            nodes: vec![enr],
+        });
+        // expected hex output
+        let expected_output = hex::decode("04f87f0101b87bf879b877f875b8401ce2991c64993d7c84c29a00bdc871917551c7d330fca2dd0d69c706596dc655448f030b98a77d4001fd46ae0112ce26d613c5a6a02a81a6223cd0c4edaa53280182696482763489736563703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138").unwrap();
+
+        let protocol_msg = ProtocolMessage { id, body };
+
+        assert_eq!(protocol_msg.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_response_ticket() {
+        // reference input
+        let id = 1;
+        let ticket = [0; 32].to_vec(); // all 0's
+        let wait_time = 5;
+        let body = RpcType::Response(Response::Ticket { ticket, wait_time });
+
+        // expected hex output
+        let expected_output = hex::decode(
+            "06e301a0000000000000000000000000000000000000000000000000000000000000000005",
+        )
+        .unwrap();
+
+        let protocol_msg = ProtocolMessage { id, body };
+
+        assert_eq!(protocol_msg.encode(), expected_output);
+    }
+
+    #[test]
+    fn ref_test_encode_response_register_topic() {
+        // reference input
+        let id = 1;
+        let registered = true;
+        let body = RpcType::Response(Response::RegisterTopic { registered });
+
+        // expected hex output
+        let expected_output = hex::decode("08c20101").unwrap();
+
+        let protocol_msg = ProtocolMessage { id, body };
+
+        assert_eq!(protocol_msg.encode(), expected_output);
+    }
+
+
     #[test]
     fn encode_decode_ping_request() {
         let request = ProtocolMessage {


### PR DESCRIPTION
## Description

Add reference tests for all `Packet` types and all `ProtocolMessage` types.
Partially fixes #10 