### PR TITLE
protocols/gossipsub: Move to stable futures

### DIFF
--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -26,6 +26,7 @@ smallvec = "1.0.0"
 
 [dev-dependencies]
 env_logger = "0.6.0"
+async-std = "1.0"
 libp2p = { path = "../../" }
 libp2p-plaintext = { version = "0.14.0-alpha.1", path = "../plaintext" }
 libp2p-yamux = { version = "0.14.0-alpha.1", path = "../../muxers/yamux" }

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -6,15 +6,15 @@ authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 
 [dependencies]
-libp2p-swarm = { path = "../../swarm" }
-libp2p-core = { path = "../../core" }
+libp2p-swarm = { version = "0.4.0-alpha.1", path = "../../swarm" }
+libp2p-core = { version = "0.14.0-alpha.1", path = "../../core" }
 bs58 = "0.2.2"
 bytes = "0.5"
 byteorder = "1.3.1"
 fnv = "1.0.6"
 futures = { version = "0.3.1" }
 protobuf = "= 2.8.1"
-rand = "0.6.5"
+rand = "0.7.2"
 futures_codec = "0.3.4"
 wasm-timer = "0.2"
 unsigned-varint = { version = "0.3", features = ["futures-codec"] }
@@ -25,12 +25,8 @@ lru = "0.1.17"
 smallvec = "1.0.0"
 
 [dev-dependencies]
-env_logger = "0.6.0"
 async-std = "1.0"
-libp2p = { path = "../../" }
+env_logger = "0.7.1"
 libp2p-plaintext = { version = "0.14.0-alpha.1", path = "../plaintext" }
 libp2p-yamux = { version = "0.14.0-alpha.1", path = "../../muxers/yamux" }
 quickcheck = "0.9.0"
-rand = "0.7.2"
-tokio = "0.1"
-tokio-stdin-stdout = "0.1"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -9,16 +9,15 @@ license = "MIT"
 libp2p-swarm = { path = "../../swarm" }
 libp2p-core = { path = "../../core" }
 bs58 = "0.2.2"
-bytes = "0.4.11"
+bytes = "0.5"
 byteorder = "1.3.1"
 fnv = "1.0.6"
-futures = "0.1.25"
-protobuf = "2.3.0"
+futures = { version = "0.3.1" }
+protobuf = "= 2.8.1"
 rand = "0.6.5"
-tokio-codec = "0.1.1"
-tokio-io = "0.1.11"
-tokio-timer = "0.2.8"
-unsigned-varint = "0.2.2"
+futures_codec = "0.3.4"
+wasm-timer = "0.2"
+unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 log = "0.4.6"
 sha2 = "0.8.0"
 base64 = "0.10.1"
@@ -28,8 +27,8 @@ smallvec = "1.0.0"
 [dev-dependencies]
 env_logger = "0.6.0"
 libp2p = { path = "../../" }
-libp2p-plaintext = { path = "../plaintext" }
-libp2p-yamux = { path = "../../muxers/yamux" }
+libp2p-plaintext = { version = "0.14.0-alpha.1", path = "../plaintext" }
+libp2p-yamux = { version = "0.14.0-alpha.1", path = "../../muxers/yamux" }
 quickcheck = "0.9.0"
 rand = "0.7.2"
 tokio = "0.1"

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -3,6 +3,7 @@
 #[cfg(test)]
 mod tests {
     use super::super::*;
+    use async_std::net::TcpStream;
 
     // helper functions for testing
 
@@ -13,14 +14,14 @@ mod tests {
         topics: Vec<String>,
         to_subscribe: bool,
     ) -> (
-        Gossipsub<tokio::net::TcpStream>,
+        Gossipsub<TcpStream>,
         Vec<PeerId>,
         Vec<TopicHash>,
     ) {
         // generate a default GossipsubConfig
         let gs_config = GossipsubConfig::default();
         // create a gossipsub struct
-        let mut gs: Gossipsub<tokio::net::TcpStream> = Gossipsub::new(PeerId::random(), gs_config);
+        let mut gs: Gossipsub<TcpStream> = Gossipsub::new(PeerId::random(), gs_config);
 
         let mut topic_hashes = vec![];
 
@@ -40,7 +41,7 @@ mod tests {
         for _ in 0..peer_no {
             let peer = PeerId::random();
             peers.push(peer.clone());
-            <Gossipsub<tokio::net::TcpStream> as NetworkBehaviour>::inject_connected(
+            <Gossipsub<TcpStream> as NetworkBehaviour>::inject_connected(
                 &mut gs,
                 peer.clone(),
                 dummy_connected_point.clone(),

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -306,7 +306,6 @@ where
                                 Some(OutboundSubstreamState::WaitingOutput(substream))
                         }
                         Poll::Ready(Err(e)) => {
-                            // TODO: Is this what we want?
                             return Poll::Ready(ProtocolsHandlerEvent::Close(e))
                         }
                         Poll::Pending => {
@@ -325,8 +324,8 @@ where
                         }
                         break;
                     }
-                    Poll::Ready(Err(_)) => {
-                        // TODO: Why do we not at least log the error (`_`)?
+                    Poll::Ready(Err(e)) => {
+                        debug!("Outbound substream error while closing: {:?}", e);
                         return Poll::Ready(ProtocolsHandlerEvent::Close(io::Error::new(
                             io::ErrorKind::BrokenPipe,
                             "Failed to close outbound substream",

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -27,10 +27,13 @@ use libp2p_swarm::protocols_handler::{
 };
 use log::{trace, warn};
 use smallvec::SmallVec;
-use std::borrow::Cow;
-use std::io;
-use tokio_codec::Framed;
-use tokio_io::{AsyncRead, AsyncWrite};
+use std::{
+    borrow::Cow,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures_codec::Framed;
 
 /// Protocol Handler that manages a single long-lived substream with a peer.
 pub struct GossipsubHandler<TSubstream>
@@ -119,7 +122,7 @@ where
 
 impl<TSubstream> ProtocolsHandler for GossipsubHandler<TSubstream>
 where
-    TSubstream: AsyncRead + AsyncWrite,
+    TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     type InEvent = GossipsubRpc;
     type OutEvent = GossipsubRpc;
@@ -135,7 +138,7 @@ where
 
     fn inject_fully_negotiated_inbound(
         &mut self,
-        substream: <Self::InboundProtocol as InboundUpgrade<TSubstream>>::Output,
+        substream: <Self::InboundProtocol as InboundUpgrade<Negotiated<TSubstream>>>::Output,
     ) {
         // new inbound substream. Replace the current one, if it exists.
         trace!("New inbound substream request");
@@ -144,7 +147,7 @@ where
 
     fn inject_fully_negotiated_outbound(
         &mut self,
-        substream: <Self::OutboundProtocol as OutboundUpgrade<TSubstream>>::Output,
+        substream: <Self::OutboundProtocol as OutboundUpgrade<Negotiated<TSubstream>>>::Output,
         message: Self::OutboundOpenInfo,
     ) {
         // Should never establish a new outbound substream if one already exists.
@@ -180,20 +183,20 @@ where
 
     fn poll(
         &mut self,
-    ) -> Poll<
-        ProtocolsHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::OutEvent>,
-        io::Error,
-    > {
+        cx: &mut Context,
+    ) -> Poll<ProtocolsHandlerEvent<
+        Self::OutboundProtocol, Self::OutboundOpenInfo, Self::OutEvent, Self::Error,
+    >> {
         // determine if we need to create the stream
         if !self.send_queue.is_empty() && self.outbound_substream.is_none() {
             let message = self.send_queue.remove(0);
             self.send_queue.shrink_to_fit();
-            return Ok(Async::Ready(
+            return Poll::Ready(
                 ProtocolsHandlerEvent::OutboundSubstreamRequest {
                     protocol: self.listen_protocol.clone(),
                     info: message,
                 },
-            ));
+            );
         }
 
         loop {
@@ -203,44 +206,46 @@ where
             ) {
                 // inbound idle state
                 Some(InboundSubstreamState::WaitingInput(mut substream)) => {
-                    match substream.poll() {
-                        Ok(Async::Ready(Some(message))) => {
+                    match substream.poll_next_unpin(cx) {
+                        Poll::Ready(Some(Ok(message))) => {
                             self.inbound_substream =
                                 Some(InboundSubstreamState::WaitingInput(substream));
-                            return Ok(Async::Ready(ProtocolsHandlerEvent::Custom(message)));
+                            return Poll::Ready(ProtocolsHandlerEvent::Custom(message));
+                        }
+                        Poll::Ready(Some(Err(e))) => {
+                            // TODO: Should we really just close here? Not even log the error?
+                            self.inbound_substream = Some(InboundSubstreamState::Closing(substream));
                         }
                         // peer closed the stream
-                        Ok(Async::Ready(None)) => {
+                        Poll::Ready(None) => {
                             self.inbound_substream =
                                 Some(InboundSubstreamState::Closing(substream));
                         }
-                        Ok(Async::NotReady) => {
+                        Poll::Pending => {
                             self.inbound_substream =
                                 Some(InboundSubstreamState::WaitingInput(substream));
                             break;
                         }
-                        Err(_) => {
-                            self.inbound_substream = Some(InboundSubstreamState::Closing(substream))
-                        }
                     }
                 }
-                Some(InboundSubstreamState::Closing(mut substream)) => match substream.close() {
-                    Ok(Async::Ready(())) => {
+                Some(InboundSubstreamState::Closing(mut substream)) => match Sink::poll_close(Pin::new(&mut substream), cx) {
+                    Poll::Ready(Ok(())) => {
                         self.inbound_substream = None;
                         if self.outbound_substream.is_none() {
                             self.keep_alive = KeepAlive::No;
                         }
                         break;
                     }
-                    Ok(Async::NotReady) => {
-                        self.inbound_substream = Some(InboundSubstreamState::Closing(substream));
-                        break;
-                    }
-                    Err(_) => {
-                        return Err(io::Error::new(
+                    // TODO: Shouldn't we at least log the error in debug mode?
+                    Poll::Ready(Err(_)) => {
+                        return Poll::Ready(ProtocolsHandlerEvent::Close(io::Error::new(
                             io::ErrorKind::BrokenPipe,
                             "Failed to close stream",
-                        ))
+                        )))
+                    }
+                    Poll::Pending => {
+                        self.inbound_substream = Some(InboundSubstreamState::Closing(substream));
+                        break;
                     }
                 },
                 None => {
@@ -272,12 +277,23 @@ where
                     }
                 }
                 Some(OutboundSubstreamState::PendingSend(mut substream, message)) => {
-                    match substream.start_send(message)? {
-                        AsyncSink::Ready => {
-                            self.outbound_substream =
-                                Some(OutboundSubstreamState::PendingFlush(substream))
+                    match Sink::poll_ready(Pin::new(&mut substream), cx) {
+                        Poll::Ready(Ok(())) => {
+                            match Sink::start_send(Pin::new(&mut substream), message) {
+                                Ok(()) => {
+                                    self.outbound_substream =
+                                        Some(OutboundSubstreamState::PendingFlush(substream))
+                                }
+                                Err(e) => {
+                                    return Poll::Ready(ProtocolsHandlerEvent::Close(e));
+                                }
+                            }
                         }
-                        AsyncSink::NotReady(message) => {
+                        Poll::Ready(Err(e)) => {
+                            // TODO: Is this what we want?
+                            return Poll::Ready(ProtocolsHandlerEvent::Close(e));
+                        }
+                        Poll::Pending => {
                             self.outbound_substream =
                                 Some(OutboundSubstreamState::PendingSend(substream, message));
                             break;
@@ -285,12 +301,16 @@ where
                     }
                 }
                 Some(OutboundSubstreamState::PendingFlush(mut substream)) => {
-                    match substream.poll_complete()? {
-                        Async::Ready(()) => {
+                    match Sink::poll_flush(Pin::new(&mut substream), cx) {
+                        Poll::Ready(Ok(())) => {
                             self.outbound_substream =
                                 Some(OutboundSubstreamState::WaitingOutput(substream))
                         }
-                        Async::NotReady => {
+                        Poll::Ready(Err(e)) => {
+                            // TODO: Is this what we want?
+                            return Poll::Ready(ProtocolsHandlerEvent::Close(e))
+                        }
+                        Poll::Pending => {
                             self.outbound_substream =
                                 Some(OutboundSubstreamState::PendingFlush(substream));
                             break;
@@ -298,23 +318,24 @@ where
                     }
                 }
                 // Currently never used - manual shutdown may implement this in the future
-                Some(OutboundSubstreamState::_Closing(mut substream)) => match substream.close() {
-                    Ok(Async::Ready(())) => {
+                Some(OutboundSubstreamState::_Closing(mut substream)) => match Sink::poll_close(Pin::new(&mut substream), cx) {
+                    Poll::Ready(Ok(()) )=> {
                         self.outbound_substream = None;
                         if self.inbound_substream.is_none() {
                             self.keep_alive = KeepAlive::No;
                         }
                         break;
                     }
-                    Ok(Async::NotReady) => {
-                        self.outbound_substream = Some(OutboundSubstreamState::_Closing(substream));
-                        break;
-                    }
-                    Err(_) => {
-                        return Err(io::Error::new(
+                    Poll::Ready(Err(_)) => {
+                        // TODO: Why do we not at least log the error (`_`)?
+                        return Poll::Ready(ProtocolsHandlerEvent::Close(io::Error::new(
                             io::ErrorKind::BrokenPipe,
                             "Failed to close outbound substream",
-                        ))
+                        )))
+                    }
+                    Poll::Pending => {
+                        self.outbound_substream = Some(OutboundSubstreamState::_Closing(substream));
+                        break;
                     }
                 },
                 None => {
@@ -327,6 +348,6 @@ where
             }
         }
 
-        Ok(Async::NotReady)
+        Poll::Pending
     }
 }

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -25,7 +25,7 @@ use libp2p_core::upgrade::{InboundUpgrade, Negotiated, OutboundUpgrade};
 use libp2p_swarm::protocols_handler::{
     KeepAlive, ProtocolsHandler, ProtocolsHandlerEvent, ProtocolsHandlerUpgrErr, SubstreamProtocol,
 };
-use log::{trace, warn};
+use log::{debug, trace, warn};
 use smallvec::SmallVec;
 use std::{
     borrow::Cow,
@@ -213,7 +213,7 @@ where
                             return Poll::Ready(ProtocolsHandlerEvent::Custom(message));
                         }
                         Poll::Ready(Some(Err(e))) => {
-                            // TODO: Should we really just close here? Not even log the error?
+                            debug!("Inbound substream error while awaiting input: {:?}", e);
                             self.inbound_substream = Some(InboundSubstreamState::Closing(substream));
                         }
                         // peer closed the stream
@@ -236,8 +236,8 @@ where
                         }
                         break;
                     }
-                    // TODO: Shouldn't we at least log the error in debug mode?
-                    Poll::Ready(Err(_)) => {
+                    Poll::Ready(Err(e)) => {
+                        debug!("Inbound substream error while closing: {:?}", e);
                         return Poll::Ready(ProtocolsHandlerEvent::Close(io::Error::new(
                             io::ErrorKind::BrokenPipe,
                             "Failed to close stream",
@@ -290,7 +290,6 @@ where
                             }
                         }
                         Poll::Ready(Err(e)) => {
-                            // TODO: Is this what we want?
                             return Poll::Ready(ProtocolsHandlerEvent::Close(e));
                         }
                         Poll::Pending => {


### PR DESCRIPTION
This moves the `protocols/gossipsub` crate to stable futures along the lines of https://github.com/libp2p/rust-libp2p/pull/1328.

Let's get https://github.com/sigp/rust-libp2p/pull/21 in first and then follow up with this pull request.

Only the last 4 commits are relevant, the remainder is from merging https://github.com/libp2p/rust-libp2p/pull/1328.



