### PR TITLE
[Discv5] Fix bug in FindNode query

### DIFF
--- a/misc/discv5/src/query_pool/peers/closest.rs
+++ b/misc/discv5/src/query_pool/peers/closest.rs
@@ -150,7 +150,6 @@ where
 
         let key = node_id.clone().into();
         let distance = key.distance(&self.target_key);
-        let num_closest = self.closest_peers.len();
 
         // Mark the peer's progress, the total nodes it has returned and it's current iteration.
         // If iterations have been completed and the node returned peers, mark it as succeeded.
@@ -161,16 +160,12 @@ where
                     debug_assert!(self.num_waiting > 0);
                     self.num_waiting -= 1;
                     let peer = e.get_mut();
-                    peer.peers_returned += num_closest;
+                    peer.peers_returned += closer_peers.len();
                     if peer.peers_returned >= self.config.num_results {
                         peer.state = QueryPeerState::Succeeded;
                     } else if self.iterations == peer.iteration {
-                        if peer.peers_returned > 0 {
-                            // mark the peer as succeeded
-                            peer.state = QueryPeerState::Succeeded;
-                        } else {
-                            peer.state = QueryPeerState::Failed; // didn't return any peers
-                        }
+                        // mark the peer as succeeded
+                        peer.state = QueryPeerState::Succeeded;
                     } else {
                         // still have iteration's to complete
                         peer.iteration += 1;
@@ -179,16 +174,12 @@ where
                 }
                 QueryPeerState::Unresponsive => {
                     let peer = e.get_mut();
-                    peer.peers_returned += num_closest;
+                    peer.peers_returned += closer_peers.len();
                     if peer.peers_returned >= self.config.num_results {
                         peer.state = QueryPeerState::Succeeded;
                     } else if self.iterations == peer.iteration {
-                        if peer.peers_returned > 0 {
-                            // mark the peer as succeeded
-                            peer.state = QueryPeerState::Succeeded;
-                        } else {
-                            peer.state = QueryPeerState::Failed; // didn't return any peers
-                        }
+                        // mark the peer as succeeded
+                        peer.state = QueryPeerState::Succeeded;
                     } else {
                         // still have iteration's to complete
                         peer.iteration += 1;
@@ -203,6 +194,7 @@ where
         }
 
         let mut progress = false;
+        let num_closest = self.closest_peers.len();
 
         // Incorporate the reported closer peers into the query.
         for peer in closer_peers {


### PR DESCRIPTION
The `on_success` function in `FindNodeQuery` was incorrectly incrementing `peer.peers_returned` by the total closest peers found in the query. It should be incremented by the length of the `closer_peers` found in that invocation of `on_success`. 

However, making this change resulted in peers getting marked as `Failed` when they failed to return > 0 peers after all iterations complete. Not returning any peers shouldn't be a criteria for failure as it's possible that the target node is in some far off bucket relative to the peer. This PR removes the condition that the node should be marked as `Failed` if it returns 0 peers.