### PR TITLE
Prefer ordered collections (BTreeMap / BTreeSet) over hash based collections

### DIFF
--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -14,7 +14,6 @@ libp2p-swarm = { version = "0.20.0", path = "../../swarm" }
 libp2p-core = { version = "0.20.0", path = "../../core" }
 bytes = "0.5.4"
 byteorder = "1.3.2"
-fnv = "1.0.6"
 futures = "0.3.1"
 rand = "0.7.3"
 futures_codec = "0.4.0"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -443,7 +443,7 @@ impl Gossipsub {
     /// requests it with an IWANT control message.
     fn handle_ihave(&mut self, peer_id: &PeerId, ihave_msgs: Vec<(TopicHash, Vec<MessageId>)>) {
         debug!("Handling IHAVE for peer: {:?}", peer_id);
-        // use a hashset to avoid duplicates efficiently
+        // use a set to avoid duplicates efficiently
         let mut iwant_ids = BTreeSet::new();
 
         for (topic, ids) in ihave_msgs {

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -86,7 +86,7 @@ mod tests {
 
         assert!(
             gs.mesh.get(&topic_hashes[0]).is_some(),
-            "Subscribe should add a new entry to the mesh[topic] hashmap"
+            "Subscribe should add a new entry to the mesh[topic] map"
         );
 
         // collect all the subscriptions
@@ -300,7 +300,7 @@ mod tests {
 
         assert!(
             gs.mesh.get(&topic_hashes[0]).is_some(),
-            "Subscribe should add a new entry to the mesh[topic] hashmap"
+            "Subscribe should add a new entry to the mesh[topic] map"
         );
 
         // all peers should be subscribed to the topic
@@ -358,7 +358,7 @@ mod tests {
 
         assert!(
             gs.mesh.get(&topic_hashes[0]).is_some(),
-            "Subscribe should add a new entry to the mesh[topic] hashmap"
+            "Subscribe should add a new entry to the mesh[topic] map"
         );
         // Unsubscribe from topic
         assert!(

--- a/protocols/gossipsub/src/mcache.rs
+++ b/protocols/gossipsub/src/mcache.rs
@@ -17,9 +17,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
-
-extern crate fnv;
-
 use crate::protocol::{GossipsubMessage, MessageId};
 use crate::topic::TopicHash;
 use std::collections::HashMap;

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -410,7 +410,7 @@ impl Decoder for GossipsubCodec {
 }
 
 /// A type for gossipsub message ids.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MessageId(Vec<u8>);
 
 impl MessageId {


### PR DESCRIPTION
I somehow screwed up with git yesterday (changing too many repos at the same time), so here is another attempt...

---

This is a matter of preference/taste. So take it or leave it :-)

- Order based collections in general are not slower than hash based collections for the cases we are looking at here
see e.g. https://users.rust-lang.org/t/hashmap-vs-btreemap/13804
for peer ids, the Ord instance is very fast since they are essentially random and therefore will differ in some way in the first few bytes
- to get best performance out of rust hash based collections, you need to use a quick, deterministic hasher like https://docs.rs/fnv/1.0.7/fnv/struct.FnvHasher.html . But then you are open to hash collision attacks again. Using ordered collections completely avoids the problem and is IMHO much simpler.
- Hash-based collections with the default hasher intentionally introduce non-determinism (see https://doc.rust-lang.org/beta/std/collections/hash_map/struct.RandomState.html ) to prevent hash collision attacks. However, I think in distributed systems you already have enough nondeterminism, you don't need to add some for completely deterministic things
- Hash-based collections cause things like debug output to be non-deterministic, complicating debugging