### PR TITLE
Estimate message size

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -674,6 +674,16 @@ impl Gossipsub {
             messages: vec![message],
             control_msgs: Vec::new(),
         });
+
+        // check that the size doesn't exceed the max transmission size
+        if event.size() > self.config.max_transmit_size() {
+            // NOTE: The size limit can be reached by excessive topics or an excessive message.
+            // This is an estimate that should be within 10% of the true encoded value. It is
+            // possible to have a message that exceeds the RPC limit and is not caught here. A
+            // warning log will be emitted in this case.
+            return Err(PublishError::MessageTooLarge);
+        }
+
         // Send to peers we know are subscribed to the topic.
         for peer_id in recipient_peers.iter() {
             debug!("Sending message to peer: {:?}", peer_id);

--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -33,6 +33,9 @@ pub enum PublishError {
     SigningError(SigningError),
     /// There were no peers to send this message to.
     InsufficientPeers,
+    /// The overall message was too large. This could be due to excessive topics or an excessive
+    /// message size.
+    MessageTooLarge,
 }
 
 impl From<SigningError> for PublishError {


### PR DESCRIPTION
Estimates the RPC message size before publishing. This informs the user if they attempt to publish a message that is over the maximum transmission size. 