### PR TITLE
Cleanup code add logs

### DIFF
--- a/examples/gossipsub-chat.rs
+++ b/examples/gossipsub-chat.rs
@@ -101,7 +101,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .expect("Correct configuration");
 
         // subscribes to our topic
-        gossipsub.subscribe(topic.clone()).unwrap();
+        gossipsub.subscribe(&topic).unwrap();
 
         // add an explicit peer if one was provided
         if let Some(explicit) = std::env::args().nth(2) {

--- a/examples/gossipsub-chat.rs
+++ b/examples/gossipsub-chat.rs
@@ -94,11 +94,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             .build()
             .expect("Valid config");
         // build a gossipsub network behaviour
-        let mut gossipsub = gossipsub::Gossipsub::new(
-            MessageAuthenticity::Author(local_peer_id.clone()),
-            gossipsub_config,
-        )
-        .expect("Correct configuration");
+        let mut gossipsub =
+            gossipsub::Gossipsub::new(MessageAuthenticity::Signed(local_key), gossipsub_config)
+                .expect("Correct configuration");
 
         // subscribes to our topic
         gossipsub.subscribe(&topic).unwrap();

--- a/examples/ipfs-private.rs
+++ b/examples/ipfs-private.rs
@@ -262,10 +262,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         };
 
         println!("Subscribing to {:?}", gossipsub_topic);
-        behaviour
-            .gossipsub
-            .subscribe(gossipsub_topic.clone())
-            .unwrap();
+        behaviour.gossipsub.subscribe(&gossipsub_topic).unwrap();
         Swarm::new(transport, behaviour, local_peer_id.clone())
     };
 

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -12,24 +12,24 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 libp2p-swarm = { version = "0.22.0", path = "../../swarm" }
 libp2p-core = { version = "0.21.0", path = "../../core" }
-bytes = "0.5.4"
-byteorder = "1.3.2"
-fnv = "1.0.6"
-futures = "0.3.1"
+bytes = "0.5.6"
+byteorder = "1.3.4"
+fnv = "1.0.7"
+futures = "0.3.5"
 rand = "0.7.3"
-futures_codec = "0.4.0"
+futures_codec = "0.4.1"
 wasm-timer = "0.2.4"
-unsigned-varint = { version = "0.4.0", features = ["futures-codec"] }
-log = "0.4.8"
-sha2 = "0.8.1"
-base64 = "0.11.0"
-smallvec = "1.1.0"
+unsigned-varint = { version = "0.5.0", features = ["futures-codec"] }
+log = "0.4.11"
+sha2 = "0.9.1"
+base64 = "0.12.3"
+smallvec = "1.4.2"
 prost = "0.6.1"
 hex_fmt = "0.3.0"
 lru_time_cache = "0.10.0"
 
 [dev-dependencies]
-async-std = "1.6.2"
+async-std = "1.6.3"
 env_logger = "0.7.1"
 libp2p-plaintext = { path = "../plaintext" }
 libp2p-yamux = { path = "../../muxers/yamux" }
@@ -37,4 +37,4 @@ quickcheck = "0.9.2"
 hex = "0.4.2"
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.6.1"

--- a/protocols/gossipsub/src/backoff.rs
+++ b/protocols/gossipsub/src/backoff.rs
@@ -1,0 +1,176 @@
+// Copyright 2020 Sigma Prime Pty Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Data structure for efficiently storing known back-off's when Pruning peers.
+use crate::topic::TopicHash;
+use libp2p_core::PeerId;
+use std::collections::{
+    hash_map::{Entry, HashMap},
+    HashSet,
+};
+use std::time::Duration;
+use wasm_timer::Instant;
+
+/// Stores backoffs in an efficient manner.
+pub struct BackoffStorage {
+    /// Stores backoffs and the index in backoffs_by_heartbeat per peer per topic.
+    backoffs: HashMap<TopicHash, HashMap<PeerId, (Instant, usize)>>,
+    /// Stores peer topic pairs per heartbeat (this is cyclic the current index is
+    /// heartbeat_index).
+    backoffs_by_heartbeat: Vec<HashSet<(TopicHash, PeerId)>>,
+    /// The index in the backoffs_by_heartbeat vector corresponding to the current heartbeat.
+    heartbeat_index: usize,
+    /// The heartbeat interval duration from the config.
+    heartbeat_interval: Duration,
+    /// Backoff slack from the config.
+    backoff_slack: u32,
+}
+
+impl BackoffStorage {
+    fn heartbeats(d: &Duration, heartbeat_interval: &Duration) -> usize {
+        ((d.as_nanos() + heartbeat_interval.as_nanos() - 1) / heartbeat_interval.as_nanos())
+            as usize
+    }
+
+    pub fn new(
+        prune_backoff: &Duration,
+        heartbeat_interval: Duration,
+        backoff_slack: u32,
+    ) -> BackoffStorage {
+        // We add one additional slot for partial heartbeat
+        let max_heartbeats =
+            Self::heartbeats(prune_backoff, &heartbeat_interval) + backoff_slack as usize + 1;
+        BackoffStorage {
+            backoffs: HashMap::new(),
+            backoffs_by_heartbeat: vec![HashSet::new(); max_heartbeats],
+            heartbeat_index: 0,
+            heartbeat_interval,
+            backoff_slack,
+        }
+    }
+
+    /// Updates the backoff for a peer (if there is already a more restrictive backoff than this call
+    /// doesn't change anything).
+    pub fn update_backoff(&mut self, topic: &TopicHash, peer: &PeerId, time: Duration) {
+        let instant = Instant::now() + time;
+        let insert_into_backoffs_by_heartbeat =
+            |heartbeat_index: usize,
+             backoffs_by_heartbeat: &mut Vec<HashSet<_>>,
+             heartbeat_interval,
+             backoff_slack| {
+                let pair = (topic.clone(), peer.clone());
+                let index = (heartbeat_index
+                    + Self::heartbeats(&time, heartbeat_interval)
+                    + backoff_slack as usize)
+                    % backoffs_by_heartbeat.len();
+                backoffs_by_heartbeat[index].insert(pair);
+                index
+            };
+        match self
+            .backoffs
+            .entry(topic.clone())
+            .or_insert_with(HashMap::new)
+            .entry(peer.clone())
+        {
+            Entry::Occupied(mut o) => {
+                let &(backoff, index) = o.get();
+                if backoff < instant {
+                    let pair = (topic.clone(), peer.clone());
+                    if let Some(s) = self.backoffs_by_heartbeat.get_mut(index) {
+                        s.remove(&pair);
+                    }
+                    let index = insert_into_backoffs_by_heartbeat(
+                        self.heartbeat_index,
+                        &mut self.backoffs_by_heartbeat,
+                        &self.heartbeat_interval,
+                        self.backoff_slack,
+                    );
+                    o.insert((instant, index));
+                }
+            }
+            Entry::Vacant(v) => {
+                let index = insert_into_backoffs_by_heartbeat(
+                    self.heartbeat_index,
+                    &mut self.backoffs_by_heartbeat,
+                    &self.heartbeat_interval,
+                    self.backoff_slack,
+                );
+                v.insert((instant, index));
+            }
+        };
+    }
+
+    /// Checks if a given peer is backoffed for the given topic. This method respects the
+    /// configured BACKOFF_SLACK and may return true even if the backup is already over.
+    /// It is guaranteed to return false if the backoff is not over and eventually if enough time
+    /// passed true if the backoff is over.
+    ///
+    /// This method should be used for deciding if we can already send a GRAFT to a previously
+    /// backoffed peer.
+    pub fn is_backoff_with_slack(&self, topic: &TopicHash, peer: &PeerId) -> bool {
+        self.backoffs
+            .get(topic)
+            .map_or(false, |m| m.contains_key(peer))
+    }
+
+    pub fn get_backoff_time(&self, topic: &TopicHash, peer: &PeerId) -> Option<Instant> {
+        Self::get_backoff_time_from_backoffs(&self.backoffs, topic, peer)
+    }
+
+    fn get_backoff_time_from_backoffs(
+        backoffs: &HashMap<TopicHash, HashMap<PeerId, (Instant, usize)>>,
+        topic: &TopicHash,
+        peer: &PeerId,
+    ) -> Option<Instant> {
+        backoffs
+            .get(topic)
+            .and_then(|m| m.get(peer).map(|(i, _)| *i))
+    }
+
+    /// Applies a heartbeat. That should be called regularly in intervals of length
+    /// `heartbeat_interval`.
+    pub fn heartbeat(&mut self) {
+        // Clean up backoffs_by_heartbeat
+        if let Some(s) = self.backoffs_by_heartbeat.get_mut(self.heartbeat_index) {
+            let backoffs = &mut self.backoffs;
+            let slack = self.heartbeat_interval * self.backoff_slack;
+            let now = Instant::now();
+            s.retain(|(topic, peer)| {
+                let keep = match Self::get_backoff_time_from_backoffs(backoffs, topic, peer) {
+                    Some(backoff_time) => backoff_time + slack > now,
+                    None => false,
+                };
+                if !keep {
+                    //remove from backoffs
+                    if let Entry::Occupied(mut m) = backoffs.entry(topic.clone()) {
+                        if m.get_mut().remove(peer).is_some() && m.get().is_empty() {
+                            m.remove();
+                        }
+                    }
+                }
+
+                keep
+            });
+        }
+
+        // Increase heartbeat index
+        self.heartbeat_index = (self.heartbeat_index + 1) % self.backoffs_by_heartbeat.len();
+    }
+}

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -18,18 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::cmp::{max, Ordering};
-use std::collections::hash_map::Entry;
-use std::iter::FromIterator;
-use std::net::IpAddr;
-use std::time::Duration;
 use std::{
+    cmp::{max, Ordering},
     collections::HashSet,
     collections::VecDeque,
-    collections::{hash_map::HashMap, BTreeSet},
+    collections::{BTreeSet, HashMap},
     fmt, iter,
+    iter::FromIterator,
+    net::IpAddr,
     sync::Arc,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures::StreamExt;
@@ -48,6 +47,7 @@ use libp2p_swarm::{
     ProtocolsHandler,
 };
 
+use crate::backoff::BackoffStorage;
 use crate::config::{GossipsubConfig, ValidationMode};
 use crate::error::PublishError;
 use crate::gossip_promises::GossipPromises;
@@ -195,153 +195,6 @@ impl From<MessageAuthenticity> for PublishConfig {
             MessageAuthenticity::RandomAuthor => PublishConfig::RandomAuthor,
             MessageAuthenticity::Anonymous => PublishConfig::Anonymous,
         }
-    }
-}
-
-/// Stores backoffs in an efficient manner.
-struct BackoffStorage {
-    /// Stores backoffs and the index in backoffs_by_heartbeat per peer per topic.
-    backoffs: HashMap<TopicHash, HashMap<PeerId, (Instant, usize)>>,
-    /// Stores peer topic pairs per heartbeat (this is cyclic the current index is
-    /// heartbeat_index).
-    backoffs_by_heartbeat: Vec<HashSet<(TopicHash, PeerId)>>,
-    /// The index in the backoffs_by_heartbeat vector corresponding to the current heartbeat.
-    heartbeat_index: usize,
-    /// The heartbeat interval duration from the config.
-    heartbeat_interval: Duration,
-    /// Backoff slack from the config.
-    backoff_slack: u32,
-}
-
-impl BackoffStorage {
-    fn heartbeats(d: &Duration, heartbeat_interval: &Duration) -> usize {
-        ((d.as_nanos() + heartbeat_interval.as_nanos() - 1) / heartbeat_interval.as_nanos())
-            as usize
-    }
-
-    pub fn new(
-        prune_backoff: &Duration,
-        heartbeat_interval: Duration,
-        backoff_slack: u32,
-    ) -> BackoffStorage {
-        // We add one additional slot for partial heartbeat
-        let max_heartbeats =
-            Self::heartbeats(prune_backoff, &heartbeat_interval) + backoff_slack as usize + 1;
-        BackoffStorage {
-            backoffs: HashMap::new(),
-            backoffs_by_heartbeat: vec![HashSet::new(); max_heartbeats],
-            heartbeat_index: 0,
-            heartbeat_interval,
-            backoff_slack,
-        }
-    }
-
-    /// Updates the backoff for a peer (if there is already a more restrictive backoff than this call
-    /// doesn't change anything).
-    pub fn update_backoff(&mut self, topic: &TopicHash, peer: &PeerId, time: Duration) {
-        let instant = Instant::now() + time;
-        let insert_into_backoffs_by_heartbeat =
-            |heartbeat_index: usize,
-             backoffs_by_heartbeat: &mut Vec<HashSet<_>>,
-             heartbeat_interval,
-             backoff_slack| {
-                let pair = (topic.clone(), peer.clone());
-                let index = (heartbeat_index
-                    + Self::heartbeats(&time, heartbeat_interval)
-                    + backoff_slack as usize)
-                    % backoffs_by_heartbeat.len();
-                backoffs_by_heartbeat[index].insert(pair);
-                index
-            };
-        match self
-            .backoffs
-            .entry(topic.clone())
-            .or_insert_with(HashMap::new)
-            .entry(peer.clone())
-        {
-            Entry::Occupied(mut o) => {
-                let &(backoff, index) = o.get();
-                if backoff < instant {
-                    let pair = (topic.clone(), peer.clone());
-                    if let Some(s) = self.backoffs_by_heartbeat.get_mut(index) {
-                        s.remove(&pair);
-                    }
-                    let index = insert_into_backoffs_by_heartbeat(
-                        self.heartbeat_index,
-                        &mut self.backoffs_by_heartbeat,
-                        &self.heartbeat_interval,
-                        self.backoff_slack,
-                    );
-                    o.insert((instant, index));
-                }
-            }
-            Entry::Vacant(v) => {
-                let index = insert_into_backoffs_by_heartbeat(
-                    self.heartbeat_index,
-                    &mut self.backoffs_by_heartbeat,
-                    &self.heartbeat_interval,
-                    self.backoff_slack,
-                );
-                v.insert((instant, index));
-            }
-        };
-    }
-
-    /// Checks if a given peer is backoffed for the given topic. This method respects the
-    /// configured BACKOFF_SLACK and may return true even if the backup is already over.
-    /// It is guaranteed to return false if the backoff is not over and eventually if enough time
-    /// passed true if the backoff is over.
-    ///
-    /// This method should be used for deciding if we can already send a GRAFT to a previously
-    /// backoffed peer.
-    pub fn is_backoff_with_slack(&self, topic: &TopicHash, peer: &PeerId) -> bool {
-        self.backoffs
-            .get(topic)
-            .map_or(false, |m| m.contains_key(peer))
-    }
-
-    pub fn get_backoff_time(&self, topic: &TopicHash, peer: &PeerId) -> Option<Instant> {
-        Self::get_backoff_time_from_backoffs(&self.backoffs, topic, peer)
-    }
-
-    fn get_backoff_time_from_backoffs(
-        backoffs: &HashMap<TopicHash, HashMap<PeerId, (Instant, usize)>>,
-        topic: &TopicHash,
-        peer: &PeerId,
-    ) -> Option<Instant> {
-        backoffs
-            .get(topic)
-            .and_then(|m| m.get(peer).map(|(i, _)| *i))
-    }
-
-    /// Applies a heartbeat. That should be called regularly in intervals of length
-    /// `heartbeat_interval`.
-    pub fn heartbeat(&mut self) {
-        // Clean up backoffs_by_heartbeat
-        if let Some(s) = self.backoffs_by_heartbeat.get_mut(self.heartbeat_index) {
-            let backoffs = &mut self.backoffs;
-            let slack = self.heartbeat_interval * self.backoff_slack;
-            let now = Instant::now();
-            s.retain(|(topic, peer)| {
-                let keep = match Self::get_backoff_time_from_backoffs(backoffs, topic, peer) {
-                    Some(backoff_time) => backoff_time + slack > now,
-                    None => false,
-                };
-                if !keep {
-                    //remove from backoffs
-                    if let Entry::Occupied(mut m) = backoffs.entry(topic.clone()) {
-                        if m.get_mut().remove(peer).is_some() && m.get().is_empty() {
-                            m.remove();
-                        }
-                    }
-                }
-
-                keep
-            });
-        }
-
-        // Increase heartbeat index
-        self.heartbeat_index = (self.heartbeat_index + 1) % self.backoffs_by_heartbeat.len();
     }
 }
 
@@ -504,7 +357,7 @@ impl Gossipsub {
     /// Subscribe to a topic.
     ///
     /// Returns true if the subscription worked. Returns false if we were already subscribed.
-    pub fn subscribe<H: Hasher>(&mut self, topic: Topic<H>) -> Result<bool, PublishError> {
+    pub fn subscribe<H: Hasher>(&mut self, topic: &Topic<H>) -> Result<bool, PublishError> {
         debug!("Subscribing to topic: {}", topic);
         let topic_hash = topic.hash();
         if self.mesh.get(&topic_hash).is_some() {
@@ -543,11 +396,11 @@ impl Gossipsub {
     /// Unsubscribes from a topic.
     ///
     /// Returns true if we were subscribed to this topic.
-    pub fn unsubscribe<H: Hasher>(&mut self, topic: Topic<H>) -> Result<bool, PublishError> {
+    pub fn unsubscribe<H: Hasher>(&mut self, topic: &Topic<H>) -> Result<bool, PublishError> {
         debug!("Unsubscribing from topic: {}", topic);
-        let topic_hash = &topic.hash();
+        let topic_hash = topic.hash();
 
-        if self.mesh.get(topic_hash).is_none() {
+        if self.mesh.get(&topic_hash).is_none() {
             debug!("Already unsubscribed from topic: {:?}", topic_hash);
             // we are not subscribed
             return Ok(false);

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -2631,6 +2631,10 @@ impl NetworkBehaviour for Gossipsub {
                 } else if let Some(old_kind) = self.peer_protocols.get_mut(&propagation_source) {
                     // Only change the value if the old value is Floodsub (the default set in
                     // inject_connected). All other PeerKind changes are ignored.
+                    debug!(
+                        "New peer type found: {} for peer: {}",
+                        kind, propagation_source
+                    );
                     if let PeerKind::Floodsub = *old_kind {
                         *old_kind = kind;
                     }

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -2622,6 +2622,10 @@ impl NetworkBehaviour for Gossipsub {
             HandlerEvent::PeerKind(kind) => {
                 // We have identified the protocol this peer is using
                 if let PeerKind::NotSupported = kind {
+                    debug!(
+                        "Peer does not support gossipsub protocols. {}",
+                        propagation_source
+                    );
                     // We treat this peer as disconnected
                     self.inject_disconnected(&propagation_source);
                 } else if let Some(old_kind) = self.peer_protocols.get_mut(&propagation_source) {

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -2495,7 +2495,7 @@ impl NetworkBehaviour for Gossipsub {
                 Some(topics) => (topics),
                 None => {
                     if !self.blacklisted_peers.contains(peer_id) {
-                        warn!("Disconnected node, not in connected nodes");
+                        debug!("Disconnected node, not in connected nodes");
                     }
                     return;
                 }

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -122,7 +122,7 @@ mod tests {
         // subscribe to the topics
         for t in topics {
             let topic = Topic::new(t);
-            gs.subscribe(topic.clone()).unwrap();
+            gs.subscribe(&topic).unwrap();
             topic_hashes.push(topic.hash().clone());
         }
 
@@ -393,11 +393,11 @@ mod tests {
 
         // unsubscribe from both topics
         assert!(
-            gs.unsubscribe(topics[0].clone()).unwrap(),
+            gs.unsubscribe(&topics[0]).unwrap(),
             "should be able to unsubscribe successfully from each topic",
         );
         assert!(
-            gs.unsubscribe(topics[1].clone()).unwrap(),
+            gs.unsubscribe(&topics[1]).unwrap(),
             "should be able to unsubscribe successfully from each topic",
         );
 
@@ -454,17 +454,17 @@ mod tests {
 
         // unsubscribe, then call join to invoke functionality
         assert!(
-            gs.unsubscribe(topics[0].clone()).unwrap(),
+            gs.unsubscribe(&topics[0]).unwrap(),
             "should be able to unsubscribe successfully"
         );
         assert!(
-            gs.unsubscribe(topics[1].clone()).unwrap(),
+            gs.unsubscribe(&topics[1]).unwrap(),
             "should be able to unsubscribe successfully"
         );
 
         // re-subscribe - there should be peers associated with the topic
         assert!(
-            gs.subscribe(topics[0].clone()).unwrap(),
+            gs.subscribe(&topics[0]).unwrap(),
             "should be able to subscribe successfully"
         );
 
@@ -509,7 +509,7 @@ mod tests {
         }
 
         // subscribe to topic1
-        gs.subscribe(topics[1].clone()).unwrap();
+        gs.subscribe(&topics[1]).unwrap();
 
         // the three new peers should have been added, along with 3 more from the pool.
         assert!(
@@ -621,7 +621,7 @@ mod tests {
         );
         // Unsubscribe from topic
         assert!(
-            gs.unsubscribe(Topic::new(fanout_topic.clone())).unwrap(),
+            gs.unsubscribe(&Topic::new(fanout_topic.clone())).unwrap(),
             "should be able to unsubscribe successfully from topic"
         );
 
@@ -1433,7 +1433,7 @@ mod tests {
         }
 
         //subscribe now to topic
-        gs.subscribe(topic.clone()).unwrap();
+        gs.subscribe(&topic).unwrap();
 
         //only peer 1 is in the mesh not peer 0 (which is an explicit peer)
         assert_eq!(
@@ -1491,7 +1491,7 @@ mod tests {
         gs.publish(topic.clone(), vec![1, 2, 3]).unwrap();
 
         //subscribe now to topic
-        gs.subscribe(topic.clone()).unwrap();
+        gs.subscribe(&topic).unwrap();
 
         //only peer 1 is in the mesh not peer 0 (which is an explicit peer)
         assert_eq!(
@@ -1875,7 +1875,7 @@ mod tests {
         let other_topic = Topic::new("test2");
 
         // subscribe an additional new peer to test2
-        gs.subscribe(other_topic.clone()).unwrap();
+        gs.subscribe(&other_topic).unwrap();
         add_peer(&mut gs, &vec![other_topic.hash()], false, false);
 
         //publish message

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -284,6 +284,7 @@ impl ProtocolsHandler for GossipsubHandler {
                                 // clear all substreams so the keep alive returns false
                                 self.inbound_substream = None;
                                 self.outbound_substream = None;
+                                self.keep_alive = KeepAlive::No;
                                 return Poll::Ready(ProtocolsHandlerEvent::Custom(
                                     HandlerEvent::PeerKind(PeerKind::NotSupported),
                                 ));

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -138,6 +138,7 @@
 pub mod error;
 pub mod protocol;
 
+mod backoff;
 mod behaviour;
 mod config;
 mod gossip_promises;

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -311,3 +311,14 @@ impl fmt::Debug for GossipsubRpc {
         b.finish()
     }
 }
+
+impl fmt::Display for PeerKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotSupported => write!(f, "Not Supported"),
+            Self::Floodsub => write!(f, "Floodsub"),
+            Self::Gossipsub => write!(f, "Gossipsub v1.0"),
+            Self::Gossipsubv1_1 => write!(f, "Gossipsub v1.1"),
+        }
+    }
+}

--- a/protocols/gossipsub/tests/smoke.rs
+++ b/protocols/gossipsub/tests/smoke.rs
@@ -213,7 +213,7 @@ fn multi_hop_propagation() {
         // Subscribe each node to the same topic.
         let topic = Topic::new("test-net");
         for (_addr, node) in &mut graph.nodes {
-            node.subscribe(topic.clone()).unwrap();
+            node.subscribe(&topic).unwrap();
         }
 
         // Wait for all nodes to be subscribed.


### PR DESCRIPTION
- Shifts the backoff struct into its own module.
- Sets the keep-alive to No for peers that don't suppor the protocol
- Improves debug logs for connecting peers regarding their protocol support
- Takes a topic reference for subscribe/unsubscribe