### PR TITLE
Remove lru_time_cache_dep

### DIFF
--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -26,7 +26,6 @@ base64 = "0.12.3"
 smallvec = "1.4.2"
 prost = "0.6.1"
 hex_fmt = "0.3.0"
-lru_time_cache = "0.10.0"
 
 [dev-dependencies]
 async-std = "1.6.3"


### PR DESCRIPTION
Removes the unnecessary `lru_time_cache` dependency