### PR TITLE
use generic type for message data + cache message ids

### DIFF
--- a/examples/gossipsub-chat.rs
+++ b/examples/gossipsub-chat.rs
@@ -51,7 +51,7 @@ use env_logger::{Builder, Env};
 use futures::prelude::*;
 use libp2p::gossipsub::MessageId;
 use libp2p::gossipsub::{
-    GossipsubEvent, GossipsubMessage, IdentTopic as Topic, MessageAuthenticity, ValidationMode,
+    GossipsubEvent, RawGossipsubMessage, IdentTopic as Topic, MessageAuthenticity, ValidationMode,
 };
 use libp2p::{gossipsub, identity, PeerId};
 use std::collections::hash_map::DefaultHasher;
@@ -79,7 +79,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Create a Swarm to manage peers and events
     let mut swarm = {
         // To content-address message, we can take the hash of message and use it as an ID.
-        let message_id_fn = |message: &GossipsubMessage| {
+        let message_id_fn = |message: &RawGossipsubMessage| {
             let mut s = DefaultHasher::new();
             message.data.hash(&mut s);
             MessageId::from(s.finish().to_string())

--- a/examples/gossipsub-chat.rs
+++ b/examples/gossipsub-chat.rs
@@ -154,7 +154,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         message,
                     } => println!(
                         "Got message: {} with id: {} from peer: {:?}",
-                        String::from_utf8_lossy(&message.data),
+                        String::from_utf8_lossy(message.data()),
                         id,
                         peer_id
                     ),

--- a/examples/ipfs-private.rs
+++ b/examples/ipfs-private.rs
@@ -195,7 +195,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     message,
                 } => println!(
                     "Got message: {} with id: {} from peer: {:?}",
-                    String::from_utf8_lossy(&message.data),
+                    String::from_utf8_lossy(message.data()),
                     id,
                     peer_id
                 ),

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -73,7 +73,7 @@ mod tests;
 /// Without signing, a number of privacy preserving modes can be selected.
 ///
 /// NOTE: The default validation settings are to require signatures. The [`ValidationMode`]
-/// should be updated in the [`GossipsubConfig`] to allow for unsigned messages.
+/// should be updated in the [`GenericGossipsubConfig`] to allow for unsigned messages.
 #[derive(Clone)]
 pub enum MessageAuthenticity {
     /// Message signing is enabled. The author will be the owner of the key and the sequence number
@@ -94,7 +94,7 @@ pub enum MessageAuthenticity {
     /// The author of the message and the sequence numbers are excluded from the message.
     ///
     /// NOTE: Excluding these fields may make these messages invalid by other nodes who
-    /// enforce validation of these fields. See [`ValidationMode`] in the `GossipsubConfig`
+    /// enforce validation of these fields. See [`ValidationMode`] in the `GenericGossipsubConfig`
     /// for how to customise this for rust-libp2p gossipsub.  A custom `message_id`
     /// function will need to be set to prevent all messages from a peer being filtered
     /// as duplicates.
@@ -203,7 +203,7 @@ impl From<MessageAuthenticity> for PublishConfig {
 
 /// Network behaviour that handles the gossipsub protocol.
 ///
-/// NOTE: Initialisation requires a [`MessageAuthenticity`] and [`GossipsubConfig`] instance. If message signing is
+/// NOTE: Initialisation requires a [`MessageAuthenticity`] and [`GenericGossipsubConfig`] instance. If message signing is
 /// disabled, the [`ValidationMode`] in the config should be adjusted to an appropriate level to
 /// accept unsigned messages.
 pub struct GenericGossipsub<T: AsRef<[u8]>> {
@@ -290,7 +290,7 @@ pub struct GenericGossipsub<T: AsRef<[u8]>> {
 pub type Gossipsub = GenericGossipsub<Vec<u8>>;
 
 impl<T: Clone + Into<Vec<u8>> + From<Vec<u8>> + AsRef<[u8]>> GenericGossipsub<T> {
-    /// Creates a `Gossipsub` struct given a set of parameters specified via a `GossipsubConfig`.
+    /// Creates a `GenericGossipsub` struct given a set of parameters specified via a `GenericGossipsubConfig`.
     pub fn new(
         privacy: MessageAuthenticity,
         config: GenericGossipsubConfig<T>,
@@ -2186,7 +2186,7 @@ impl<T: Clone + Into<Vec<u8>> + From<Vec<u8>> + AsRef<[u8]>> GenericGossipsub<T>
         }
     }
 
-    /// Constructs a `GossipsubMessage` performing message signing if required.
+    /// Constructs a `GenericGossipsubMessage` performing message signing if required.
     pub(crate) fn build_message(
         &self,
         topics: Vec<TopicHash>,

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -48,7 +48,7 @@ use libp2p_swarm::{
 };
 
 use crate::backoff::BackoffStorage;
-use crate::config::{GossipsubConfig, ValidationMode};
+use crate::config::{GenericGossipsubConfig, ValidationMode};
 use crate::error::PublishError;
 use crate::gossip_promises::GossipPromises;
 use crate::handler::{GossipsubHandler, HandlerEvent};
@@ -58,12 +58,13 @@ use crate::protocol::SIGNING_PREFIX;
 use crate::time_cache::DuplicateCache;
 use crate::topic::{Hasher, Topic, TopicHash};
 use crate::types::{
-    GossipsubControlAction, GossipsubMessage, GossipsubSubscription, GossipsubSubscriptionAction,
-    MessageAcceptance, MessageId, PeerInfo,
+    GenericGossipsubMessage, GossipsubControlAction, GossipsubMessageWithId, GossipsubSubscription,
+    GossipsubSubscriptionAction, MessageAcceptance, MessageId, PeerInfo, RawGossipsubMessage,
 };
 use crate::types::{GossipsubRpc, PeerKind};
 use crate::{rpc_proto, TopicScoreParams};
 use std::cmp::Ordering::Equal;
+use std::fmt::Debug;
 
 mod tests;
 
@@ -119,7 +120,7 @@ impl MessageAuthenticity {
 
 /// Event that can happen on the gossipsub behaviour.
 #[derive(Debug)]
-pub enum GossipsubEvent {
+pub enum GenericGossipsubEvent<T: AsRef<[u8]>> {
     /// A message has been received.    
     Message {
         /// The peer that forwarded us this message.
@@ -128,7 +129,7 @@ pub enum GossipsubEvent {
         /// validating a message (if required).
         message_id: MessageId,
         /// The message itself.
-        message: GossipsubMessage,
+        message: GossipsubMessageWithId<T>,
     },
     /// A remote subscribed to a topic.
     Subscribed {
@@ -146,6 +147,8 @@ pub enum GossipsubEvent {
         topic: TopicHash,
     },
 }
+//for backwards compatibility
+pub type GossipsubEvent = GenericGossipsubEvent<Vec<u8>>;
 
 /// A data structure for storing configuration for publishing messages. See [`MessageAuthenticity`]
 /// for further details.
@@ -203,12 +206,12 @@ impl From<MessageAuthenticity> for PublishConfig {
 /// NOTE: Initialisation requires a [`MessageAuthenticity`] and [`GossipsubConfig`] instance. If message signing is
 /// disabled, the [`ValidationMode`] in the config should be adjusted to an appropriate level to
 /// accept unsigned messages.
-pub struct Gossipsub {
+pub struct GenericGossipsub<T: AsRef<[u8]>> {
     /// Configuration providing gossipsub performance parameters.
-    config: GossipsubConfig,
+    config: GenericGossipsubConfig<T>,
 
     /// Events that need to be yielded to the outside when polling.
-    events: VecDeque<NetworkBehaviourAction<Arc<rpc_proto::Rpc>, GossipsubEvent>>,
+    events: VecDeque<NetworkBehaviourAction<Arc<rpc_proto::Rpc>, GenericGossipsubEvent<T>>>,
 
     /// Pools non-urgent control messages between heartbeats.
     control_pool: HashMap<PeerId, Vec<GossipsubControlAction>>,
@@ -250,7 +253,7 @@ pub struct Gossipsub {
     backoffs: BackoffStorage,
 
     /// Message cache for the last few heartbeats.
-    mcache: MessageCache,
+    mcache: MessageCache<T>,
 
     /// Heartbeat interval stream.
     heartbeat: Interval,
@@ -283,11 +286,14 @@ pub struct Gossipsub {
     published_message_ids: DuplicateCache<MessageId>,
 }
 
-impl Gossipsub {
+// for backwards compatibility
+pub type Gossipsub = GenericGossipsub<Vec<u8>>;
+
+impl<T: Clone + Into<Vec<u8>> + From<Vec<u8>> + AsRef<[u8]>> GenericGossipsub<T> {
     /// Creates a `Gossipsub` struct given a set of parameters specified via a `GossipsubConfig`.
     pub fn new(
         privacy: MessageAuthenticity,
-        config: GossipsubConfig,
+        config: GenericGossipsubConfig<T>,
     ) -> Result<Self, &'static str> {
         // Set up the router given the configuration settings.
 
@@ -297,7 +303,7 @@ impl Gossipsub {
 
         // Set up message publishing parameters.
 
-        Ok(Gossipsub {
+        Ok(GenericGossipsub {
             events: VecDeque::new(),
             control_pool: HashMap::new(),
             publish_config: privacy.into(),
@@ -314,11 +320,7 @@ impl Gossipsub {
                 config.heartbeat_interval(),
                 config.backoff_slack(),
             ),
-            mcache: MessageCache::new(
-                config.history_gossip(),
-                config.history_length(),
-                config.message_id_fn(),
-            ),
+            mcache: MessageCache::new(config.history_gossip(), config.history_length()),
             heartbeat: Interval::new_at(
                 Instant::now() + config.heartbeat_initial_delay(),
                 config.heartbeat_interval(),
@@ -462,7 +464,7 @@ impl Gossipsub {
     pub fn publish<H: Hasher>(
         &mut self,
         topic: Topic<H>,
-        data: impl Into<Vec<u8>>,
+        data: impl Into<T>,
     ) -> Result<MessageId, PublishError> {
         self.publish_many(iter::once(topic), data)
     }
@@ -471,20 +473,22 @@ impl Gossipsub {
     pub fn publish_many<H: Hasher>(
         &mut self,
         topics: impl IntoIterator<Item = Topic<H>>,
-        data: impl Into<Vec<u8>>,
+        data: impl Into<T>,
     ) -> Result<MessageId, PublishError> {
         let message =
             self.build_message(topics.into_iter().map(|t| t.hash()).collect(), data.into())?;
-        let msg_id = (self.config.message_id_fn())(&message);
+        let msg_id = self.config.message_id(&message);
 
         let event = Arc::new(
             GossipsubRpc {
                 subscriptions: Vec::new(),
-                messages: vec![message.clone()],
+                messages: vec![RawGossipsubMessage::from(message.clone())],
                 control_msgs: Vec::new(),
             }
             .into_protobuf(),
         );
+
+        let message = GossipsubMessageWithId::new(message, msg_id.clone());
 
         // check that the size doesn't exceed the max transmission size
         if event.encoded_len() > self.config.max_transmit_size() {
@@ -723,11 +727,7 @@ impl Gossipsub {
         }
 
         let interval = Interval::new(params.decay_interval);
-        let peer_score = PeerScore::new_with_message_delivery_time_callback(
-            params,
-            self.config.message_id_fn(),
-            callback,
-        );
+        let peer_score = PeerScore::new_with_message_delivery_time_callback(params, callback);
         self.peer_score = Some((peer_score, threshold, interval, GossipPromises::default()));
         Ok(())
     }
@@ -1085,7 +1085,10 @@ impl Gossipsub {
         if !cached_messages.is_empty() {
             debug!("IWANT: Sending cached messages to peer: {:?}", peer_id);
             // Send the messages to the peer
-            let message_list = cached_messages.into_iter().map(|entry| entry.1).collect();
+            let message_list = cached_messages
+                .into_iter()
+                .map(|entry| RawGossipsubMessage::from(entry.1))
+                .collect();
             if let Err(_) = self.send_message(
                 peer_id.clone(),
                 GossipsubRpc {
@@ -1326,8 +1329,10 @@ impl Gossipsub {
 
     /// Handles a newly received GossipsubMessage.
     /// Forwards the message to all peers in the mesh.
-    fn handle_received_message(&mut self, mut msg: GossipsubMessage, propagation_source: &PeerId) {
-        let msg_id = (self.config.message_id_fn())(&msg);
+    fn handle_received_message(&mut self, msg: RawGossipsubMessage, propagation_source: &PeerId) {
+        let msg = GenericGossipsubMessage::from(msg);
+        let msg_id = self.config.message_id(&msg);
+        let mut msg = GossipsubMessageWithId::new(msg, msg_id.clone());
         debug!(
             "Handling message: {:?} from peer: {}",
             msg_id,
@@ -1421,9 +1426,9 @@ impl Gossipsub {
         if self.mesh.keys().any(|t| msg.topics.iter().any(|u| t == u)) {
             debug!("Sending received message to user");
             self.events.push_back(NetworkBehaviourAction::GenerateEvent(
-                GossipsubEvent::Message {
+                GenericGossipsubEvent::Message {
                     propagation_source: propagation_source.clone(),
-                    message_id: msg_id,
+                    message_id: msg_id.clone(),
                     message: msg.clone(),
                 },
             ));
@@ -1437,11 +1442,10 @@ impl Gossipsub {
 
         // forward the message to mesh peers, if no validation is required
         if !self.config.validate_messages() {
-            let message_id = (self.config.message_id_fn())(&msg);
             if let Err(_) = self.forward_msg(msg, Some(propagation_source)) {
                 error!("Failed to forward message. Too large");
             }
-            debug!("Completed message handling for message: {:?}", message_id);
+            debug!("Completed message handling for message: {:?}", msg_id);
         }
     }
 
@@ -1530,7 +1534,7 @@ impl Gossipsub {
                     }
                     // generates a subscription event to be polled
                     application_event.push(NetworkBehaviourAction::GenerateEvent(
-                        GossipsubEvent::Subscribed {
+                        GenericGossipsubEvent::Subscribed {
                             peer_id: propagation_source.clone(),
                             topic: subscription.topic_hash.clone(),
                         },
@@ -1554,7 +1558,7 @@ impl Gossipsub {
 
                     // generate an unsubscribe event to be polled
                     application_event.push(NetworkBehaviourAction::GenerateEvent(
-                        GossipsubEvent::Unsubscribed {
+                        GenericGossipsubEvent::Unsubscribed {
                             peer_id: propagation_source.clone(),
                             topic: subscription.topic_hash.clone(),
                         },
@@ -2119,10 +2123,10 @@ impl Gossipsub {
     /// Returns true if at least one peer was messaged.
     fn forward_msg(
         &mut self,
-        message: GossipsubMessage,
+        message: GossipsubMessageWithId<T>,
         propagation_source: Option<&PeerId>,
     ) -> Result<bool, PublishError> {
-        let msg_id = (self.config.message_id_fn())(&message);
+        let msg_id = message.message_id();
 
         // message is fully validated inform peer_score
         if let Some((peer_score, ..)) = &mut self.peer_score {
@@ -2165,7 +2169,7 @@ impl Gossipsub {
             let event = Arc::new(
                 GossipsubRpc {
                     subscriptions: Vec::new(),
-                    messages: vec![message.clone()],
+                    messages: vec![RawGossipsubMessage::from(message.clone())],
                     control_msgs: Vec::new(),
                 }
                 .into_protobuf(),
@@ -2186,8 +2190,8 @@ impl Gossipsub {
     pub(crate) fn build_message(
         &self,
         topics: Vec<TopicHash>,
-        data: Vec<u8>,
-    ) -> Result<GossipsubMessage, SigningError> {
+        data: T,
+    ) -> Result<GenericGossipsubMessage<T>, SigningError> {
         match &self.publish_config {
             PublishConfig::Signing {
                 ref keypair,
@@ -2200,7 +2204,7 @@ impl Gossipsub {
                 let signature = {
                     let message = rpc_proto::Message {
                         from: Some(author.clone().into_bytes()),
-                        data: Some(data.clone()),
+                        data: Some(data.clone().into()),
                         seqno: Some(sequence_number.to_be_bytes().to_vec()),
                         topic_ids: topics
                             .clone()
@@ -2222,7 +2226,7 @@ impl Gossipsub {
                     Some(keypair.sign(&signature_bytes)?)
                 };
 
-                Ok(GossipsubMessage {
+                Ok(GenericGossipsubMessage {
                     source: Some(author.clone()),
                     data,
                     // To be interoperable with the go-implementation this is treated as a 64-bit
@@ -2235,7 +2239,7 @@ impl Gossipsub {
                 })
             }
             PublishConfig::Author(peer_id) => {
-                Ok(GossipsubMessage {
+                Ok(GenericGossipsubMessage {
                     source: Some(peer_id.clone()),
                     data,
                     // To be interoperable with the go-implementation this is treated as a 64-bit
@@ -2248,7 +2252,7 @@ impl Gossipsub {
                 })
             }
             PublishConfig::RandomAuthor => {
-                Ok(GossipsubMessage {
+                Ok(GenericGossipsubMessage {
                     source: Some(PeerId::random()),
                     data,
                     // To be interoperable with the go-implementation this is treated as a 64-bit
@@ -2261,7 +2265,7 @@ impl Gossipsub {
                 })
             }
             PublishConfig::Anonymous => {
-                Ok(GossipsubMessage {
+                Ok(GenericGossipsubMessage {
                     source: None,
                     data,
                     // To be interoperable with the go-implementation this is treated as a 64-bit
@@ -2524,9 +2528,12 @@ fn get_ip_addr(addr: &Multiaddr) -> Option<IpAddr> {
     })
 }
 
-impl NetworkBehaviour for Gossipsub {
+impl<T> NetworkBehaviour for GenericGossipsub<T>
+where
+    T: Send + 'static + Clone + Into<Vec<u8>> + From<Vec<u8>> + AsRef<[u8]>,
+{
     type ProtocolsHandler = GossipsubHandler;
-    type OutEvent = GossipsubEvent;
+    type OutEvent = GenericGossipsubEvent<T>;
 
     fn new_handler(&mut self) -> Self::ProtocolsHandler {
         GossipsubHandler::new(
@@ -2789,11 +2796,13 @@ impl NetworkBehaviour for Gossipsub {
 
                 // Handle any invalid messages from this peer
                 if let Some((peer_score, .., gossip_promises)) = &mut self.peer_score {
-                    let id_fn = self.config.message_id_fn();
                     for (message, validation_error) in invalid_messages {
                         let reason = RejectReason::ValidationError(validation_error);
+                        let message = GenericGossipsubMessage::from(message);
+                        let id = self.config.message_id(&message);
+                        let message = GossipsubMessageWithId::new(message, id);
                         peer_score.reject_message(&propagation_source, &message, reason);
-                        gossip_promises.reject_message(&id_fn(&message), &reason);
+                        gossip_promises.reject_message(&message.message_id(), &reason);
                     }
                 } else {
                     // log the invalid messages
@@ -2934,7 +2943,7 @@ fn validate_config(
     Ok(())
 }
 
-impl fmt::Debug for Gossipsub {
+impl<T: Debug + AsRef<[u8]>> fmt::Debug for GenericGossipsub<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Gossipsub")
             .field("config", &self.config)
@@ -2983,8 +2992,8 @@ mod local_test {
         }
     }
 
-    fn test_message() -> GossipsubMessage {
-        GossipsubMessage {
+    fn test_message() -> RawGossipsubMessage {
+        RawGossipsubMessage {
             source: Some(PeerId::random()),
             data: vec![0; 100],
             sequence_number: None,
@@ -3030,7 +3039,7 @@ mod local_test {
     /// Tests RPC message fragmentation
     fn test_message_fragmentation_deterministic() {
         let max_transmit_size = 500;
-        let config = crate::GossipsubConfigBuilder::new()
+        let config = crate::GenericGossipsubConfigBuilder::new()
             .max_transmit_size(max_transmit_size)
             .validation_mode(ValidationMode::Permissive)
             .build()
@@ -3078,7 +3087,7 @@ mod local_test {
     fn test_message_fragmentation() {
         fn prop(rpc: GossipsubRpc) {
             let max_transmit_size = 500;
-            let config = crate::GossipsubConfigBuilder::new()
+            let config = crate::GenericGossipsubConfigBuilder::new()
                 .max_transmit_size(max_transmit_size)
                 .validation_mode(ValidationMode::Permissive)
                 .build()

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -133,8 +133,8 @@ pub struct GenericGossipsubConfig<T> {
     /// addressing, where this function may be set to `hash(message)`. This would prevent messages
     /// of the same content from being duplicated.
     ///
-    /// The function takes a `GossipsubMessage` as input and outputs a String to be interpreted as
-    /// the message id.
+    /// The function takes a `GenericGossipsubMessage` as input and outputs a String to be
+    /// interpreted as the message id.
     message_id_fn: fn(&GenericGossipsubMessage<T>) -> MessageId,
 
     /// By default, gossipsub will reject messages that are sent to us that has the same message
@@ -345,7 +345,7 @@ impl<T> GenericGossipsubConfig<T> {
     /// addressing, where this function may be set to `hash(message)`. This would prevent messages
     /// of the same content from being duplicated.
     ///
-    /// The function takes a `GossipsubMessage` as input and outputs a String to be interpreted as
+    /// The function takes a `GenericGossipsubMessage` as input and outputs a String to be interpreted as
     /// the message id.
     pub fn message_id(&self, message: &GenericGossipsubMessage<T>) -> MessageId {
         (self.message_id_fn)(message)
@@ -677,7 +677,7 @@ impl<T: Clone> GenericGossipsubConfigBuilder<T> {
     /// addressing, where this function may be set to `hash(message)`. This would prevent messages
     /// of the same content from being duplicated.
     ///
-    /// The function takes a `GossipsubMessage` as input and outputs a String to be interpreted as
+    /// The function takes a `GenericGossipsubMessage` as input and outputs a String to be interpreted as
     /// the message id.
     pub fn message_id_fn(
         &mut self,
@@ -809,7 +809,7 @@ impl<T: Clone> GenericGossipsubConfigBuilder<T> {
         self
     }
 
-    /// Constructs a `GossipsubConfig` from the given configuration and validates the settings.
+    /// Constructs a `GenericGossipsubConfig` from the given configuration and validates the settings.
     pub fn build(&self) -> Result<GenericGossipsubConfig<T>, &str> {
         // check all constraints on config
 

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use libp2p_core::PeerId;
 
-use crate::types::{GossipsubMessage, MessageId};
+use crate::types::{GenericGossipsubMessage, MessageId};
 
 /// The types of message validation that can be employed by gossipsub.
 #[derive(Debug, Clone)]
@@ -49,7 +49,7 @@ pub enum ValidationMode {
 
 /// Configuration parameters that define the performance of the gossipsub network.
 #[derive(Clone)]
-pub struct GossipsubConfig {
+pub struct GenericGossipsubConfig<T> {
     /// The protocol id prefix to negotiate this protocol. The protocol id is of the form
     /// `/<prefix>/<supported-versions>`. As gossipsub supports version 1.0 and 1.1, there are two
     /// protocol id's supported.
@@ -135,7 +135,7 @@ pub struct GossipsubConfig {
     ///
     /// The function takes a `GossipsubMessage` as input and outputs a String to be interpreted as
     /// the message id.
-    message_id_fn: fn(&GossipsubMessage) -> MessageId,
+    message_id_fn: fn(&GenericGossipsubMessage<T>) -> MessageId,
 
     /// By default, gossipsub will reject messages that are sent to us that has the same message
     /// source as we have specified locally. Enabling this, allows these messages and prevents
@@ -222,7 +222,10 @@ pub struct GossipsubConfig {
     published_message_ids_cache_time: Duration,
 }
 
-impl GossipsubConfig {
+// for backwards compatibility
+pub type GossipsubConfig = GenericGossipsubConfig<Vec<u8>>;
+
+impl<T> GenericGossipsubConfig<T> {
     //all the getters
 
     /// The protocol id prefix to negotiate this protocol. The protocol id is of the form
@@ -344,8 +347,8 @@ impl GossipsubConfig {
     ///
     /// The function takes a `GossipsubMessage` as input and outputs a String to be interpreted as
     /// the message id.
-    pub fn message_id_fn(&self) -> fn(&GossipsubMessage) -> MessageId {
-        self.message_id_fn
+    pub fn message_id(&self, message: &GenericGossipsubMessage<T>) -> MessageId {
+        (self.message_id_fn)(message)
     }
 
     /// By default, gossipsub will reject messages that are sent to us that has the same message
@@ -465,39 +468,42 @@ impl GossipsubConfig {
     }
 }
 
-impl Default for GossipsubConfig {
-    fn default() -> GossipsubConfig {
+impl<T: Clone> Default for GenericGossipsubConfig<T> {
+    fn default() -> Self {
         //use GossipsubConfigBuilder to also validate defaults
-        GossipsubConfigBuilder::new()
+        GenericGossipsubConfigBuilder::new()
             .build()
             .expect("Default config parameters should be valid parameters")
     }
 }
 
 /// The builder struct for constructing a gossipsub configuration.
-pub struct GossipsubConfigBuilder {
-    config: GossipsubConfig,
+pub struct GenericGossipsubConfigBuilder<T> {
+    config: GenericGossipsubConfig<T>,
 }
 
-impl Default for GossipsubConfigBuilder {
-    fn default() -> GossipsubConfigBuilder {
-        GossipsubConfigBuilder {
-            config: GossipsubConfig::default(),
+//for backwards compatibility
+pub type GossipsubConfigBuilder = GenericGossipsubConfigBuilder<Vec<u8>>;
+
+impl<T: Clone> Default for GenericGossipsubConfigBuilder<T> {
+    fn default() -> Self {
+        GenericGossipsubConfigBuilder {
+            config: GenericGossipsubConfig::default(),
         }
     }
 }
 
-impl From<GossipsubConfig> for GossipsubConfigBuilder {
-    fn from(config: GossipsubConfig) -> Self {
-        GossipsubConfigBuilder { config }
+impl<T> From<GenericGossipsubConfig<T>> for GenericGossipsubConfigBuilder<T> {
+    fn from(config: GenericGossipsubConfig<T>) -> Self {
+        GenericGossipsubConfigBuilder { config }
     }
 }
 
-impl GossipsubConfigBuilder {
+impl<T: Clone> GenericGossipsubConfigBuilder<T> {
     // set default values
-    pub fn new() -> GossipsubConfigBuilder {
-        GossipsubConfigBuilder {
-            config: GossipsubConfig {
+    pub fn new() -> Self {
+        GenericGossipsubConfigBuilder {
+            config: GenericGossipsubConfig {
                 protocol_id_prefix: Cow::Borrowed("meshsub"),
                 history_length: 5,
                 history_gossip: 3,
@@ -673,7 +679,10 @@ impl GossipsubConfigBuilder {
     ///
     /// The function takes a `GossipsubMessage` as input and outputs a String to be interpreted as
     /// the message id.
-    pub fn message_id_fn(&mut self, id_fn: fn(&GossipsubMessage) -> MessageId) -> &mut Self {
+    pub fn message_id_fn(
+        &mut self,
+        id_fn: fn(&GenericGossipsubMessage<T>) -> MessageId,
+    ) -> &mut Self {
         self.config.message_id_fn = id_fn;
         self
     }
@@ -801,7 +810,7 @@ impl GossipsubConfigBuilder {
     }
 
     /// Constructs a `GossipsubConfig` from the given configuration and validates the settings.
-    pub fn build(&self) -> Result<GossipsubConfig, &str> {
+    pub fn build(&self) -> Result<GenericGossipsubConfig<T>, &str> {
         // check all constraints on config
 
         if self.config.max_transmit_size < 100 {
@@ -832,7 +841,7 @@ impl GossipsubConfigBuilder {
     }
 }
 
-impl std::fmt::Debug for GossipsubConfig {
+impl<T> std::fmt::Debug for GenericGossipsubConfig<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut builder = f.debug_struct("GossipsubConfig");
         let _ = builder.field("protocol_id_prefix", &self.protocol_id_prefix);

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -21,7 +21,7 @@
 use crate::config::ValidationMode;
 use crate::error::{GossipsubHandlerError, ValidationError};
 use crate::protocol::{GossipsubCodec, ProtocolConfig};
-use crate::types::{GossipsubMessage, GossipsubRpc, PeerKind};
+use crate::types::{GossipsubRpc, PeerKind, RawGossipsubMessage};
 use futures::prelude::*;
 use futures::StreamExt;
 use futures_codec::Framed;
@@ -50,7 +50,7 @@ pub enum HandlerEvent {
         rpc: GossipsubRpc,
         /// Any invalid messages that were received in the RPC, along with the associated
         /// validation error.
-        invalid_messages: Vec<(GossipsubMessage, ValidationError)>,
+        invalid_messages: Vec<(RawGossipsubMessage, ValidationError)>,
     },
     /// An inbound or outbound substream has been established with the peer and this informs over
     /// which protocol. This message only occurs once per connection.

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -166,7 +166,8 @@ pub use self::peer_score::{
 };
 pub use self::topic::{Hasher, Topic, TopicHash};
 pub use self::types::{
-    GenericGossipsubMessage, GossipsubMessage, GossipsubRpc, MessageAcceptance, MessageId,
+    GenericGossipsubMessage, GossipsubMessage, RawGossipsubMessage, GossipsubRpc, MessageAcceptance,
+    MessageId,
 };
 pub type IdentTopic = Topic<self::topic::IdentityHash>;
 pub type Sha256Topic = Topic<self::topic::Sha256Hash>;

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -55,10 +55,10 @@
 //!
 //! ## GossipsubConfig
 //!
-//! The [`GossipsubConfig`] struct specifies various network performance/tuning configuration
+//! The [`GenericGossipsubConfig`] struct specifies various network performance/tuning configuration
 //! parameters. Specifically it specifies:
 //!
-//! [`GossipsubConfig`]: struct.GossipsubConfig.html
+//! [`GenericGossipsubConfig`]: struct.GenericGossipsubConfig.html
 //!
 //! - `protocol_id` - The protocol id that this implementation will accept connections on.
 //! - `history_length` - The number of heartbeats which past messages are kept in cache (default: 5).
@@ -83,16 +83,16 @@
 //! propagate the message to peers.
 //!
 //! This struct implements the `Default` trait and can be initialised via
-//! `GossipsubConfig::default()`.
+//! `GenericGossipsubConfig::default()`.
 //!
 //!
 //! ## Gossipsub
 //!
-//! The [`Gossipsub`] struct implements the `NetworkBehaviour` trait allowing it to act as the
+//! The [`GenericGossipsub`] struct implements the `NetworkBehaviour` trait allowing it to act as the
 //! routing behaviour in a `Swarm`. This struct requires an instance of `PeerId` and
-//! [`GossipsubConfig`].
+//! [`GenericGossipsubConfig`].
 //!
-//! [`Gossipsub`]: struct.Gossipsub.html
+//! [`GenericGossipsub`]: struct.Gossipsub.html
 
 //! ## Example
 //!

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -153,13 +153,20 @@ mod rpc_proto {
     include!(concat!(env!("OUT_DIR"), "/gossipsub.pb.rs"));
 }
 
-pub use self::behaviour::{Gossipsub, GossipsubEvent, MessageAuthenticity};
-pub use self::config::{GossipsubConfig, GossipsubConfigBuilder, ValidationMode};
+pub use self::behaviour::{
+    GenericGossipsub, GenericGossipsubEvent, Gossipsub, GossipsubEvent, MessageAuthenticity,
+};
+pub use self::config::{
+    GenericGossipsubConfig, GenericGossipsubConfigBuilder, GossipsubConfig, GossipsubConfigBuilder,
+    ValidationMode,
+};
 pub use self::peer_score::{
     score_parameter_decay, score_parameter_decay_with_base, PeerScoreParams, PeerScoreThresholds,
     TopicScoreParams,
 };
 pub use self::topic::{Hasher, Topic, TopicHash};
-pub use self::types::{GossipsubMessage, GossipsubRpc, MessageAcceptance, MessageId};
+pub use self::types::{
+    GenericGossipsubMessage, GossipsubMessage, GossipsubRpc, MessageAcceptance, MessageId,
+};
 pub type IdentTopic = Topic<self::topic::IdentityHash>;
 pub type Sha256Topic = Topic<self::topic::Sha256Hash>;

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -23,6 +23,7 @@ use crate::rpc_proto;
 use crate::TopicHash;
 use libp2p_core::PeerId;
 use std::fmt;
+use std::fmt::Debug;
 
 #[derive(Debug)]
 /// Validation kinds from the application for received messages.
@@ -79,12 +80,12 @@ pub enum PeerKind {
 
 /// A message received by the gossipsub system.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct GossipsubMessage {
+pub struct GenericGossipsubMessage<T> {
     /// Id of the peer that published this message.
     pub source: Option<PeerId>,
 
     /// Content of the message. Its meaning is out of scope of this library.
-    pub data: Vec<u8>,
+    pub data: T,
 
     /// A random sequence number.
     pub sequence_number: Option<u64>,
@@ -104,12 +105,69 @@ pub struct GossipsubMessage {
     pub validated: bool,
 }
 
-impl fmt::Debug for GossipsubMessage {
+impl<T> GenericGossipsubMessage<T> {
+    pub fn from<S: Into<T>>(m: GenericGossipsubMessage<S>) -> Self {
+        Self {
+            source: m.source,
+            data: m.data.into(),
+            sequence_number: m.sequence_number,
+            topics: m.topics,
+            signature: m.signature,
+            key: m.key,
+            validated: m.validated,
+        }
+    }
+}
+
+pub type RawGossipsubMessage = GenericGossipsubMessage<Vec<u8>>;
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct DataWithId<T> {
+    pub id: MessageId,
+    pub data: T,
+}
+
+impl<T: Into<Vec<u8>>> Into<Vec<u8>> for DataWithId<T> {
+    fn into(self) -> Vec<u8> {
+        self.data.into()
+    }
+}
+
+impl<T: AsRef<[u8]>> AsRef<[u8]> for DataWithId<T> {
+    fn as_ref(&self) -> &[u8] {
+        self.data.as_ref()
+    }
+}
+
+pub type GossipsubMessageWithId<T> = GenericGossipsubMessage<DataWithId<T>>;
+
+impl<T> GossipsubMessageWithId<T> {
+    pub fn new(m: GenericGossipsubMessage<T>, id: MessageId) -> Self {
+        Self {
+            source: m.source,
+            data: DataWithId { id, data: m.data },
+            sequence_number: m.sequence_number,
+            topics: m.topics,
+            signature: m.signature,
+            key: m.key,
+            validated: m.validated,
+        }
+    }
+
+    pub fn message_id(&self) -> &MessageId {
+        &self.data.id
+    }
+}
+
+// for backwards compatibility
+pub type GossipsubMessage = GossipsubMessageWithId<Vec<u8>>;
+
+impl<T: Debug + AsRef<[u8]>> fmt::Debug for GenericGossipsubMessage<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GossipsubMessage")
             .field(
                 "data",
-                &format_args!("{:<20}", &hex_fmt::HexFmt(&self.data)),
+                &format_args!("{:<20}", &hex_fmt::HexFmt(&self.data.as_ref())),
             )
             .field("source", &self.source)
             .field("sequence_number", &self.sequence_number)
@@ -179,7 +237,7 @@ pub enum GossipsubControlAction {
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct GossipsubRpc {
     /// List of messages that were part of this RPC query.
-    pub messages: Vec<GossipsubMessage>,
+    pub messages: Vec<RawGossipsubMessage>,
     /// List of subscriptions.
     pub subscriptions: Vec<GossipsubSubscription>,
     /// List of Gossipsub control messages.

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -157,6 +157,10 @@ impl<T> GossipsubMessageWithId<T> {
     pub fn message_id(&self) -> &MessageId {
         &self.data.id
     }
+
+    pub fn data(&self) -> &T {
+        &self.data.data
+    }
 }
 
 // for backwards compatibility


### PR DESCRIPTION
Introduce a generic type used for (decompressed) message data.

Furthermore caches message ids (by using the generic type to store the id within the message data)