### PR TITLE
Added Granular Metrics to Gossipsub

### DIFF
--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -29,6 +29,7 @@ hex_fmt = "0.3.0"
 regex = "1.4.0"
 strum = "0.21"
 strum_macros = "0.21"
+ttl_cache = "0.5.1"
 
 [dev-dependencies]
 async-std = "1.6.3"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -27,6 +27,8 @@ smallvec = "1.6.1"
 prost = "0.8"
 hex_fmt = "0.3.0"
 regex = "1.4.0"
+strum = "0.21"
+strum_macros = "0.21"
 
 [dev-dependencies]
 async-std = "1.6.3"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -562,7 +562,7 @@ where
                     msg_counts.churn_topic.add_assign(1);
                 }
             }
-            self.mesh_indices.remove(topic);
+            //self.mesh_indices.remove(topic);
         }
     }
 
@@ -840,12 +840,10 @@ where
         let mcache_fetch = self.mcache.validate(msg_id);
         let topic_index_tuple= match &mcache_fetch {
             Some(msg) => match self.mesh.get(&msg.topic) {
-                Some(set) if set.contains(propagation_source) => self
-                    .mesh_indices
-                    .entry(msg.topic.clone())
-                    .or_insert_with(|| HashMap::new())
-                    .get(propagation_source)
-                    .map(|f| (msg.topic.clone(), *f)),
+                Some(set) if set.contains(propagation_source) => match self.mesh_indices.get(&msg.topic) {
+                    Some(index_map) => index_map.get(propagation_source).map(|f| (msg.topic.clone(), *f)),
+                    None => Some((msg.topic.clone(), -5)),
+                }
                 Some(_) => Some((msg.topic.clone(), -3)),
                 None => Some((msg.topic.clone(), -4)),
             },

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -547,7 +547,7 @@ where
                             }
                             None => {
                                 greatest_index += 1;
-                                debug!("churn_inspect[{}] assigning peer {} new [index {}]", topic, mesh_peer, greatest_index);
+                                debug!("churn_inspect[{}] [index {}] assigning peer {} to new slot", topic, greatest_index, mesh_peer);
                                 greatest_index
                             }
                         };

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -919,7 +919,8 @@ where
     }
 
     /// This is just a utility function to verify everything is in order between the
-    /// mesh and the mesh_slot_data. It's only used in debug builds.
+    /// mesh and the mesh_slot_data. It's useful for debugging.
+    #[allow(dead_code)]
     fn validate_mesh_slots_for_topic(&self, topic: &TopicHash) -> Result<(), String> {
         match self.mesh_slot_data.get(topic) {
             Some(slot_data) => match self.mesh.get(topic) {
@@ -1036,12 +1037,16 @@ where
         }
 
         #[cfg(debug_assertions)]
-        let validation_result = self.validate_mesh_slots_for_topic(topic_hash);
-        debug_assert!(
-            validation_result.is_ok(),
-            "metrics_event: validate_mesh_slots_for_topic({}) failed! Err({})",
-            topic_hash, validation_result.err().unwrap()
-        );
+        {
+            let validation_result = self.validate_mesh_slots_for_topic(topic_hash);
+            debug_assert!(
+                validation_result.is_ok(),
+                "metrics_event: validate_mesh_slots_for_topic({}) failed! Err({})",
+                topic_hash,
+                validation_result.err().unwrap()
+            );
+        }
+
         trace!("Completed JOIN for topic: {:?}", topic_hash);
     }
 
@@ -2427,7 +2432,8 @@ where
             debug_assert!(
                 validation_result.is_ok(),
                 "metrics_event: validate_mesh_slots_for_topic({}) failed! Err({})",
-                topic, validation_result.err().unwrap()
+                topic,
+                validation_result.err().unwrap()
             );
         }
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -2120,8 +2120,20 @@ where
         // cache scores throughout the heartbeat
         let mut scores = HashMap::new();
         let peer_score = &self.peer_score;
-        let mut score = |p: &PeerId| match peer_score {
-            Some((peer_score, ..)) => *scores.entry(*p).or_insert_with(|| peer_score.score(p)),
+        let mesh_indices = &self.mesh_indices;
+        let mut score = |p: &PeerId, t: &TopicHash| match peer_score {
+            Some((peer_score, ..)) => {
+                match scores.entry(t.clone()).or_insert_with(|| HashMap::new()).get(p) {
+                    Some(x) => *x,
+                    None => {
+                        let slot_idx = match mesh_indices.get(t) {
+                            Some(mesh_index) => mesh_index.get(p).map(|f| *f),
+                            None => None,
+                        };
+                        *scores.entry(t.clone()).or_insert_with(|| HashMap::new()).entry(*p).or_insert_with(|| peer_score.score_with_index(p, slot_idx))
+                    }
+                }
+            },
             _ => 0.0,
         };
 
@@ -2140,12 +2152,12 @@ where
             let to_remove: Vec<_> = peers
                 .iter()
                 .filter(|&p| {
-                    if score(p) < 0.0 {
-                        debug!(
+                    if score(p, topic_hash) < 0.0 {
+                        trace!(
                             "HEARTBEAT: Prune peer {:?} with negative score [score = {}, topic = \
                              {}]",
                             p,
-                            score(p),
+                            score(p, topic_hash),
                             topic_hash
                         );
 
@@ -2196,7 +2208,7 @@ where
                         !peers.contains(peer)
                             && !explicit_peers.contains(peer)
                             && !backoffs.is_backoff_with_slack(topic_hash, peer)
-                            && score(peer) >= 0.0
+                            && score(peer, topic_hash) >= 0.0
                     },
                 );
                 for peer in &peer_list {
@@ -2224,7 +2236,7 @@ where
                 let mut shuffled = peers.iter().cloned().collect::<Vec<_>>();
                 shuffled.shuffle(&mut rng);
                 shuffled
-                    .sort_by(|p1, p2| score(p1).partial_cmp(&score(p2)).unwrap_or(Ordering::Equal));
+                    .sort_by(|p1, p2| score(p1, topic_hash).partial_cmp(&score(p2,topic_hash)).unwrap_or(Ordering::Equal));
                 // shuffle everything except the last retain_scores many peers (the best ones)
                 shuffled[..peers.len() - self.config.retain_scores()].shuffle(&mut rng);
 
@@ -2280,7 +2292,7 @@ where
                             !peers.contains(peer)
                                 && !explicit_peers.contains(peer)
                                 && !backoffs.is_backoff_with_slack(topic_hash, peer)
-                                && score(peer) >= 0.0
+                                && score(peer, topic_hash) >= 0.0
                                 && outbound_peers.contains(peer)
                         },
                     );
@@ -2312,7 +2324,7 @@ where
                     // now compute the median peer score in the mesh
                     let mut peers_by_score: Vec<_> = peers.iter().collect();
                     peers_by_score
-                        .sort_by(|p1, p2| score(p1).partial_cmp(&score(p2)).unwrap_or(Equal));
+                        .sort_by(|p1, p2| score(p1, topic_hash).partial_cmp(&score(p2, topic_hash)).unwrap_or(Equal));
 
                     let middle = peers_by_score.len() / 2;
                     let median = if peers_by_score.len() % 2 == 0 {
@@ -2320,10 +2332,10 @@ where
                             *peers_by_score.get(middle - 1).expect(
                                 "middle < vector length and middle > 0 since peers.len() > 0",
                             ),
-                        ) + score(*peers_by_score.get(middle).expect("middle < vector length")))
+                        topic_hash) + score(*peers_by_score.get(middle).expect("middle < vector length"), topic_hash))
                             * 0.5
                     } else {
-                        score(*peers_by_score.get(middle).expect("middle < vector length"))
+                        score(*peers_by_score.get(middle).expect("middle < vector length"), topic_hash)
                     };
 
                     // if the median score is below the threshold, select a better peer (if any) and
@@ -2338,7 +2350,7 @@ where
                                 !peers.contains(peer)
                                     && !explicit_peers.contains(peer)
                                     && !backoffs.is_backoff_with_slack(topic_hash, peer)
-                                    && score(peer) > median
+                                    && score(peer, topic_hash) > median
                             },
                         );
                         for peer in &peer_list {
@@ -2386,8 +2398,8 @@ where
                 // is the peer still subscribed to the topic?
                 match self.peer_topics.get(peer) {
                     Some(topics) => {
-                        if !topics.contains(&topic_hash) || score(peer) < publish_threshold {
-                            debug!(
+                        if !topics.contains(&topic_hash) || score(peer, topic_hash) < publish_threshold {
+                            trace!(
                                 "HEARTBEAT: Peer removed from fanout for topic: {:?}",
                                 topic_hash
                             );
@@ -2421,7 +2433,7 @@ where
                     |peer| {
                         !peers.contains(peer)
                             && !explicit_peers.contains(peer)
-                            && score(peer) < publish_threshold
+                            && score(peer, topic_hash) < publish_threshold
                     },
                 );
                 peers.extend(new_peers);
@@ -2429,12 +2441,14 @@ where
         }
 
         if self.peer_score.is_some() {
+            /*
             trace!("Peer_scores: {:?}", {
                 for peer in self.peer_topics.keys() {
                     score(peer);
                 }
                 scores
             });
+            */
             trace!("Mesh message deliveries: {:?}", {
                 self.mesh
                     .iter()

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -234,6 +234,27 @@ impl MessageCounts {
     }
 }
 
+macro_rules! increment_counter {
+    ($self: expr, $field: ident, $topic_hash: ident, $peer_id: ident) => {{
+        match $self.mesh_indices.get(&$topic_hash) {
+            Some(index_map) => match index_map.get(&$peer_id) {
+                Some(idx) => match $self.message_counts.get_mut(&$topic_hash) {
+                    Some(count_map) => match count_map.get_mut(idx) {
+                        Some(msg_counts) => {
+                            msg_counts.$field.add_assign(1);
+                            format!("churn_inspect[{}]: [index {:02}] increment {} peer {} SUCCESS", $topic_hash, idx, stringify!($field), $peer_id)
+                        },
+                        None => format!("churn_inspect[{}]: [index {:02}] increment {} peer {} FAILURE [retrieving msg_counts]", $topic_hash, idx, stringify!($field), $peer_id),
+                    },
+                    None => format!("churn_inspect[{}]: [index {:02}] increment {} peer {} FAILURE [retrieving count_map]", $topic_hash, idx, stringify!($field), $peer_id),
+                },
+                None => format!("churn_inspect[{}]: increment {} peer {} FAILURE [retrieving mesh index]", $topic_hash, stringify!($field), $peer_id),
+            },
+            None => format!("churn_inspect[{}]: increment {} peer {} FAILURE [retrieving index_map]", $topic_hash, stringify!($field), $peer_id),
+        }
+    }};
+}
+
 /// Network behaviour that handles the gossipsub protocol.
 ///
 /// NOTE: Initialisation requires a [`MessageAuthenticity`] and [`GossipsubConfig`] instance. If
@@ -541,7 +562,7 @@ where
                                 // mark this slot as churned
                                 if let Some(peer_map) = self.message_counts.get_mut(topic) {
                                     if let Some(msg_count) = peer_map.get_mut(&result) {
-                                        debug!("churn_inspect[{}]: [index {}] replacing peer {} with peer {}", topic, result, lg_peer, mesh_peer);
+                                        debug!("churn_inspect[{}]: [index {:02}] replacing peer {} with peer {}", topic, result, lg_peer, mesh_peer);
                                         msg_count.churn_total.add_assign(1);
                                     }
                                 }
@@ -549,7 +570,7 @@ where
                             }
                             None => {
                                 greatest_index += 1;
-                                debug!("churn_inspect[{}] [index {}] assigning peer {} to new slot", topic, greatest_index, mesh_peer);
+                                debug!("churn_inspect[{}]: [index {:02}] assigning peer {} to new slot", topic, greatest_index, mesh_peer);
                                 self.message_counts.entry(topic.clone()).or_insert_with(|| BTreeMap::new()).entry(greatest_index).or_insert_with(||MessageCounts::new());
                                 greatest_index
                             }
@@ -1182,23 +1203,7 @@ where
                 Self::control_pool_add(&mut self.control_pool, peer, control);
 
                 // update leave count
-                let status = match self.mesh_indices.get(topic_hash) {
-                    Some(index_map) => match index_map.get(&peer) {
-                        Some(idx) => match self.message_counts.get_mut(topic_hash) {
-                            Some(count_map) => match count_map.get_mut(idx) {
-                                Some(msg_counts) => {
-                                    msg_counts.churn_leave.add_assign(1);
-                                    format!("[index {}] SUCCESS", idx)
-                                },
-                                None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
-                            },
-                            None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
-                        },
-                        None => "FAILURE [retrieving mesh index]".to_string(),
-                    },
-                    None => "FAILURE [retrieving index_map]".to_string(),
-                };
-                debug!("churn_inspect[{}]: increment churn_leave peer {}{}", topic_hash, peer, status);
+                debug!("{}", increment_counter!(self, churn_leave, topic_hash, peer));
 
                 // If the peer did not previously exist in any mesh, inform the handler
                 peer_removed_from_mesh(
@@ -1611,23 +1616,7 @@ where
         let (below_threshold, score) =
             self.score_below_threshold(peer_id, |pst| pst.accept_px_threshold);
         for (topic_hash, px, backoff) in prune_data {
-            let status = match self.mesh_indices.get(&topic_hash) {
-                Some(index_map) => match index_map.get(peer_id) {
-                    Some(idx) => match self.message_counts.get_mut(&topic_hash) {
-                        Some(count_map) => match count_map.get_mut(idx) {
-                            Some(msg_counts) => {
-                                msg_counts.churn_prune.add_assign(1);
-                                format!("[index {}] SUCCESS", idx)
-                            },
-                            None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
-                        },
-                        None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
-                    },
-                    None => "FAILURE [retrieving mesh index]".to_string(),
-                },
-                None => "FAILURE [retrieving index_map]".to_string(),
-            };
-            debug!("churn_inspect[{}]: increment churn_prune peer {}{}", topic_hash, peer_id, status);
+            debug!("{}", increment_counter!(self, churn_prune, topic_hash, peer_id));
             self.remove_peer_from_mesh(peer_id, &topic_hash, backoff, true);
 
             if self.mesh.contains_key(&topic_hash) {
@@ -2075,23 +2064,7 @@ where
         let mut modified_topics = topics_to_graft.iter().collect::<HashSet<_>>();
         // remove unsubscribed peers from the mesh if it exists
         for (peer_id, topic_hash) in unsubscribed_peers {
-            let status = match self.mesh_indices.get(&topic_hash) {
-                Some(index_map) => match index_map.get(&peer_id) {
-                    Some(idx) => match self.message_counts.get_mut(&topic_hash) {
-                        Some(count_map) => match count_map.get_mut(idx) {
-                            Some(msg_counts) => {
-                                msg_counts.churn_unsubscribed.add_assign(1);
-                                format!("[index {}] SUCCESS", idx)
-                            },
-                            None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
-                        },
-                        None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
-                    },
-                    None => "FAILURE [retrieving mesh index]".to_string(),
-                },
-                None => "FAILURE [retrieving index_map]".to_string(),
-            };
-            debug!("churn_inspect[{}]: increment churn_unsubscribed peer {}{}", topic_hash, peer_id, status);
+            debug!("{}", increment_counter!(self, churn_unsubscribed, topic_hash, peer_id));
             self.remove_peer_from_mesh(&peer_id, &topic_hash, None, false);
             // remove_peer_from_mesh will update the peer indices for us so we don't need to update it
             modified_topics.remove(&topic_hash);
@@ -2249,23 +2222,7 @@ where
                 modified_topics.insert(topic_hash.clone());
             }
             for peer in to_remove {
-                let status = match self.mesh_indices.get(topic_hash) {
-                    Some(index_map) => match index_map.get(&peer) {
-                        Some(idx) => match self.message_counts.get_mut(topic_hash) {
-                            Some(count_map) => match count_map.get_mut(idx) {
-                                Some(msg_counts) => {
-                                    msg_counts.churn_score_negative.add_assign(1);
-                                    format!("[index {}] SUCCESS", idx)
-                                },
-                                None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
-                            },
-                            None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
-                        },
-                        None => "FAILURE [retrieving mesh index]".to_string(),
-                    },
-                    None => "FAILURE [retrieving index_map]".to_string(),
-                };
-                debug!("churn_inspect[{}]: increment churn_score_negative peer {}{}", topic_hash, peer, status);
+                debug!("{}", increment_counter!(self, churn_score_negative, topic_hash, peer));
                 peers.remove(&peer);
             }
 
@@ -2345,24 +2302,7 @@ where
                             outbound -= 1;
                         }
                     }
-
-                    let status = match self.mesh_indices.get(topic_hash) {
-                        Some(index_map) => match index_map.get(&peer) {
-                            Some(idx) => match self.message_counts.get_mut(topic_hash) {
-                                Some(count_map) => match count_map.get_mut(idx) {
-                                    Some(msg_counts) => {
-                                        msg_counts.churn_excess.add_assign(1);
-                                        format!("[index {}] SUCCESS", idx)
-                                    },
-                                    None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
-                                },
-                                None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
-                            },
-                            None => "FAILURE [retrieving mesh index]".to_string(),
-                        },
-                        None => "FAILURE [retrieving index_map]".to_string(),
-                    };
-                    debug!("churn_inspect[{}]: increment churn_excess peer {}{}", topic_hash, peer, status);
+                    debug!("{}", increment_counter!(self, churn_excess, topic_hash, peer));
 
                     // remove the peer
                     peers.remove(&peer);
@@ -3182,23 +3122,7 @@ where
                 if let Some(mesh_peers) = self.mesh.get_mut(&topic) {
                     // check if the peer is in the mesh and remove it
                     if mesh_peers.contains(peer_id) {
-                        let status = match self.mesh_indices.get(topic) {
-                            Some(index_map) => match index_map.get(peer_id) {
-                                Some(idx) => match self.message_counts.get_mut(topic) {
-                                    Some(count_map) => match count_map.get_mut(idx) {
-                                        Some(msg_counts) => {
-                                            msg_counts.churn_disconnected.add_assign(1);
-                                            format!("[index {}] SUCCESS", idx)
-                                        },
-                                        None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
-                                    },
-                                    None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
-                                },
-                                None => "FAILURE [retrieving mesh index]".to_string(),
-                            },
-                            None => "FAILURE [retrieving index_map]".to_string(),
-                        };
-                        debug!("churn_inspect[{}]: increment churn_disconnected peer {}{}", topic, peer_id, status);
+                        debug!("{}", increment_counter!(self, churn_disconnected, topic, peer_id));
                         mesh_peers.remove(peer_id);
                         modified_topics.insert(topic.clone());
                     }

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1694,10 +1694,16 @@ where
             self.score_below_threshold(peer_id, |pst| pst.accept_px_threshold);
         for (topic_hash, px, backoff) in prune_data {
             // increment churn_prune and vacate slot
-            churn_slot!(self, topic_hash, peer_id, churn_prune);
+            let mut mesh_contains_topic = false;
+            if let Some(peers) = self.mesh.get(&topic_hash) {
+                if peers.contains(&peer_id) {
+                    churn_slot!(self, topic_hash, peer_id, churn_prune);
+                }
+                mesh_contains_topic = true;
+            }
             self.remove_peer_from_mesh(peer_id, &topic_hash, backoff, true);
 
-            if self.mesh.contains_key(&topic_hash) {
+            if mesh_contains_topic {
                 //connect to px peers
                 if !px.is_empty() {
                     // we ignore PX from peers with insufficient score

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -461,6 +461,9 @@ where
         self.mesh.keys()
     }
 
+    /// Lists the hashes of the topics we have slot metrics for (regardless of whether or not we're subscribed)
+    pub fn slot_metrics_topics(&self) -> impl Iterator<Item = &TopicHash> { self.mesh_slot_data.keys() }
+
     /// Lists all mesh peers for a certain topic hash.
     pub fn mesh_peers(&self, topic_hash: &TopicHash) -> impl Iterator<Item = &PeerId> {
         self.mesh

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -2064,10 +2064,14 @@ where
         let mut modified_topics = topics_to_graft.iter().collect::<HashSet<_>>();
         // remove unsubscribed peers from the mesh if it exists
         for (peer_id, topic_hash) in unsubscribed_peers {
-            debug!("{}", increment_counter!(self, churn_unsubscribed, topic_hash, peer_id));
-            self.remove_peer_from_mesh(&peer_id, &topic_hash, None, false);
-            // remove_peer_from_mesh will update the peer indices for us so we don't need to update it
-            modified_topics.remove(&topic_hash);
+            if let Some(peers) = self.mesh.get(&topic_hash) {
+                if peers.contains(&peer_id) {
+                    debug!("{}", increment_counter!(self, churn_unsubscribed, topic_hash, peer_id));
+                    self.remove_peer_from_mesh(&peer_id, &topic_hash, None, false);
+                    // remove_peer_from_mesh will update the peer indices for us so we don't need to update it
+                    modified_topics.remove(&topic_hash);
+                }
+            }
         }
 
         for topic in modified_topics {

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -210,6 +210,7 @@ pub struct MessageCounts {
     pub churn_leave: u32,
     pub churn_unsubscribed: u32,
     pub churn_pruned: u32,
+    pub churn_topic: u32,
 }
 
 impl MessageCounts {
@@ -226,6 +227,7 @@ impl MessageCounts {
             churn_leave: 0,
             churn_unsubscribed: 0,
             churn_pruned: 0,
+            churn_topic: 0,
         }
     }
 }
@@ -554,7 +556,7 @@ where
             // we aren't subscribed to this topic anymore - churn the message counts
             if let Some(peer_map) = self.message_counts.get_mut(topic) {
                 for (.., msg_counts) in peer_map {
-                    msg_counts.churn_total.add_assign(1);
+                    msg_counts.churn_topic.add_assign(1);
                 }
             }
             self.mesh_indices.remove(topic);

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -241,6 +241,13 @@ impl MeshSlotMetrics {
             current_peer: None,
         }
     }
+
+    pub fn with_names(&self) -> impl Iterator<Item=(&str,&u32)> {
+        self.counts
+            .iter()
+            .enumerate()
+            .map(|(i,c)| (MESH_SLOT_METRIC_NAMES[i], c))
+    }
 }
 
 pub type MeshSlot = usize;

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -995,6 +995,8 @@ where
 
     /// Updates the mesh indices for a given topic. This should be called whenever the set of
     /// peers in the mesh for the topic changes (whenever a peer enters or exits the mesh).
+    /// NOTE: If the churn_slot! macro is always invoked whenever peers leave the mesh, then
+    /// this function would only need to be called when new peers enter the mesh.
     fn update_mesh_indices_for_topic(&mut self, topic: &TopicHash) {
         let slot_map = self
             .mesh_slots
@@ -1010,7 +1012,11 @@ where
             // the first element in the vector is for peers that aren't in the mesh
             .or_insert_with(|| vec![SlotMetrics::new()]);
         if let Some(mesh_peers) = self.mesh.get(topic) {
-            // iterate over mesh slots and vacate slots assigned to peers that have been removed from the mesh
+            // iterate over mesh slots and vacate slots assigned to peers that have been removed
+            // from them mesh.
+            // NOTE: If the churn_slot! macro is always invoked whenever peers leave the mesh,
+            // this loop could be removed. Leaving this loop here is just a bit of defensive
+            // coding but it could be removed as an optimization.
             for (peer, mesh_slot) in slot_map
                 .iter()
                 .filter(|(peer, ..)| !mesh_peers.contains(peer))

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -548,6 +548,7 @@ where
                             None => {
                                 greatest_index += 1;
                                 debug!("churn_inspect[{}] [index {}] assigning peer {} to new slot", topic, greatest_index, mesh_peer);
+                                self.message_counts.entry(topic.clone()).or_insert_with(|| BTreeMap::new()).entry(greatest_index).or_insert_with(||MessageCounts::new());
                                 greatest_index
                             }
                         };

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1179,17 +1179,22 @@ where
                 Self::control_pool_add(&mut self.control_pool, peer, control);
 
                 // update leave count
-                let mut status = String::from(": FAILURE");
-                if let Some(index_map) = self.mesh_indices.get(topic_hash) {
-                    if let Some(idx) = index_map.get(&peer) {
-                        if let Some(count_map) = self.message_counts.get_mut(topic_hash) {
-                            if let Some(msg_counts) = count_map.get_mut(idx) {
-                                msg_counts.churn_leave.add_assign(1);
-                                status = format!(" [index {}]: SUCCESS", idx);
-                            }
-                        }
-                    }
-                }
+                let status = match self.mesh_indices.get(topic_hash) {
+                    Some(index_map) => match index_map.get(&peer) {
+                        Some(idx) => match self.message_counts.get_mut(topic_hash) {
+                            Some(count_map) => match count_map.get_mut(idx) {
+                                Some(msg_counts) => {
+                                    msg_counts.churn_leave.add_assign(1);
+                                    format!("[index {}] SUCCESS", idx)
+                                },
+                                None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
+                            },
+                            None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
+                        },
+                        None => "FAILURE [retrieving mesh index]".to_string(),
+                    },
+                    None => "FAILURE [retrieving index_map]".to_string(),
+                };
                 debug!("churn_inspect[{}]: increment churn_leave peer {}{}", topic_hash, peer, status);
 
                 // If the peer did not previously exist in any mesh, inform the handler
@@ -2050,17 +2055,22 @@ where
         let mut modified_topics = topics_to_graft.iter().collect::<HashSet<_>>();
         // remove unsubscribed peers from the mesh if it exists
         for (peer_id, topic_hash) in unsubscribed_peers {
-            let mut status = String::from(": FAILURE");
-            if let Some(index_map) = self.mesh_indices.get(&topic_hash) {
-                if let Some(idx) = index_map.get(&peer_id) {
-                    if let Some(count_map) = self.message_counts.get_mut(&topic_hash) {
-                        if let Some(msg_counts) = count_map.get_mut(idx) {
-                            msg_counts.churn_unsubscribed.add_assign(1);
-                            status = format!(" [index {}]: SUCCESS", idx);
-                        }
-                    }
-                }
-            }
+            let status = match self.mesh_indices.get(&topic_hash) {
+                Some(index_map) => match index_map.get(&peer_id) {
+                    Some(idx) => match self.message_counts.get_mut(&topic_hash) {
+                        Some(count_map) => match count_map.get_mut(idx) {
+                            Some(msg_counts) => {
+                                msg_counts.churn_unsubscribed.add_assign(1);
+                                format!("[index {}] SUCCESS", idx)
+                            },
+                            None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
+                        },
+                        None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
+                    },
+                    None => "FAILURE [retrieving mesh index]".to_string(),
+                },
+                None => "FAILURE [retrieving index_map]".to_string(),
+            };
             debug!("churn_inspect[{}]: increment churn_unsubscribed peer {}{}", topic_hash, peer_id, status);
             self.remove_peer_from_mesh(&peer_id, &topic_hash, None, false);
             // remove_peer_from_mesh will update the peer indices for us so we don't need to update it
@@ -2219,17 +2229,22 @@ where
                 modified_topics.insert(topic_hash.clone());
             }
             for peer in to_remove {
-                let mut status = String::from(": FAILURE");
-                if let Some(index_map) = self.mesh_indices.get(topic_hash) {
-                    if let Some(mesh_index) = index_map.get(&peer) {
-                        if let Some(count_map) = self.message_counts.get_mut(topic_hash) {
-                            if let Some(msg_count) = count_map.get_mut(mesh_index) {
-                                msg_count.churn_score_negative.add_assign(1);
-                                status = format!(" [index {}]: SUCCESS", mesh_index);
-                            }
-                        }
-                    }
-                }
+                let status = match self.mesh_indices.get(topic_hash) {
+                    Some(index_map) => match index_map.get(&peer) {
+                        Some(idx) => match self.message_counts.get_mut(topic_hash) {
+                            Some(count_map) => match count_map.get_mut(idx) {
+                                Some(msg_counts) => {
+                                    msg_counts.churn_score_negative.add_assign(1);
+                                    format!("[index {}] SUCCESS", idx)
+                                },
+                                None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
+                            },
+                            None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
+                        },
+                        None => "FAILURE [retrieving mesh index]".to_string(),
+                    },
+                    None => "FAILURE [retrieving index_map]".to_string(),
+                };
                 debug!("churn_inspect[{}]: increment churn_score_negative peer {}{}", topic_hash, peer, status);
                 peers.remove(&peer);
             }
@@ -2311,17 +2326,22 @@ where
                         }
                     }
 
-                    let mut status = String::from(": FAILURE");
-                    if let Some(index_map) = self.mesh_indices.get(topic_hash) {
-                        if let Some(idx) = index_map.get(&peer) {
-                            if let Some(count_map) = self.message_counts.get_mut(topic_hash) {
-                                if let Some(msg_counts) = count_map.get_mut(idx) {
-                                    status = format!(" [index {}]: SUCCESS", idx);
-                                    msg_counts.churn_pruned.add_assign(1);
-                                }
-                            }
-                        }
-                    }
+                    let status = match self.mesh_indices.get(topic_hash) {
+                        Some(index_map) => match index_map.get(&peer) {
+                            Some(idx) => match self.message_counts.get_mut(topic_hash) {
+                                Some(count_map) => match count_map.get_mut(idx) {
+                                    Some(msg_counts) => {
+                                        msg_counts.churn_pruned.add_assign(1);
+                                        format!("[index {}] SUCCESS", idx)
+                                    },
+                                    None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
+                                },
+                                None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
+                            },
+                            None => "FAILURE [retrieving mesh index]".to_string(),
+                        },
+                        None => "FAILURE [retrieving index_map]".to_string(),
+                    };
                     debug!("churn_inspect[{}]: increment churn_pruned peer {}{}", topic_hash, peer, status);
 
                     // remove the peer
@@ -3142,17 +3162,22 @@ where
                 if let Some(mesh_peers) = self.mesh.get_mut(&topic) {
                     // check if the peer is in the mesh and remove it
                     if mesh_peers.contains(peer_id) {
-                        let mut status = String::from(": FAILURE");
-                        if let Some(index_map) = self.mesh_indices.get(topic) {
-                            if let Some(idx) = index_map.get(peer_id) {
-                                if let Some(count_map) = self.message_counts.get_mut(topic) {
-                                    if let Some(msg_counts) = count_map.get_mut(idx) {
-                                        status = format!(" [index {}]: SUCCESS", idx);
-                                        msg_counts.churn_disconnected.add_assign(1);
-                                    }
-                                }
-                            }
-                        }
+                        let status = match self.mesh_indices.get(topic) {
+                            Some(index_map) => match index_map.get(peer_id) {
+                                Some(idx) => match self.message_counts.get_mut(topic) {
+                                    Some(count_map) => match count_map.get_mut(idx) {
+                                        Some(msg_counts) => {
+                                            msg_counts.churn_disconnected.add_assign(1);
+                                            format!("[index {}] SUCCESS", idx)
+                                        },
+                                        None => format!("[index {}]: FAILURE [retrieving msg_counts]", idx),
+                                    },
+                                    None => format!("[index {}]: FAILURE [retrieving count_map]", idx),
+                                },
+                                None => "FAILURE [retrieving mesh index]".to_string(),
+                            },
+                            None => "FAILURE [retrieving index_map]".to_string(),
+                        };
                         debug!("churn_inspect[{}]: increment churn_disconnected peer {}{}", topic, peer_id, status);
                         mesh_peers.remove(peer_id);
                         modified_topics.insert(topic.clone());

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -63,9 +63,9 @@ use crate::types::{
 };
 use crate::types::{GossipsubRpc, PeerConnections, PeerKind};
 use crate::{rpc_proto, TopicScoreParams};
-use std::{cmp::Ordering::Equal, fmt::Debug};
 use std::collections::BTreeMap;
 use std::ops::AddAssign;
+use std::{cmp::Ordering::Equal, fmt::Debug};
 
 #[cfg(test)]
 mod tests;
@@ -197,6 +197,8 @@ impl From<MessageAuthenticity> for PublishConfig {
 type GossipsubNetworkBehaviourAction =
     NetworkBehaviourAction<Arc<GossipsubHandlerIn>, GossipsubEvent>;
 
+pub type MeshIndex = i32;
+
 /// Network behaviour that handles the gossipsub protocol.
 ///
 /// NOTE: Initialisation requires a [`MessageAuthenticity`] and [`GossipsubConfig`] instance. If
@@ -250,8 +252,10 @@ pub struct Gossipsub<
     mesh: HashMap<TopicHash, BTreeSet<PeerId>>,
 
     /// Map of topic to peers to first message counts
-    count_first_messages: HashMap<TopicHash, BTreeMap<PeerId, u64>>,
-    count_all_messages:  HashMap<TopicHash, BTreeMap<PeerId, u64>>,
+    count_first_messages: HashMap<TopicHash, BTreeMap<MeshIndex, u64>>,
+    count_all_messages: HashMap<TopicHash, BTreeMap<MeshIndex, u64>>,
+    /// Map of PeerId to MeshIndex for each topic
+    mesh_index: HashMap<TopicHash, HashMap<PeerId, MeshIndex>>,
 
     /// Map of topics to list of peers that we publish to, but don't subscribe to.
     fanout: HashMap<TopicHash, BTreeSet<PeerId>>,
@@ -402,8 +406,9 @@ where
             explicit_peers: HashSet::new(),
             blacklisted_peers: HashSet::new(),
             mesh: HashMap::new(),
-            count_first_messages: HashMap::new(), // HashMap<TopicHash, std::collections::BTreeMap<PeerId, u64>>,
-            count_all_messages:  HashMap::new(), // HashMap<TopicHash, std::collections::BTreeMap<PeerId, u64>>,
+            count_first_messages: HashMap::new(),
+            count_all_messages: HashMap::new(),
+            mesh_index: HashMap::new(),
             fanout: HashMap::new(),
             fanout_last_pub: HashMap::new(),
             backoffs: BackoffStorage::new(
@@ -466,12 +471,90 @@ where
             .map(|(peer_id, topic_set)| (peer_id, topic_set.iter().collect()))
     }
 
-    pub fn all_messages_count_for_topic(&self, topic: &TopicHash) -> Option<&BTreeMap<PeerId, u64>> {
+    pub fn all_messages_count_for_topic(
+        &self,
+        topic: &TopicHash,
+    ) -> Option<&BTreeMap<MeshIndex, u64>> {
         self.count_all_messages.get(topic)
     }
 
-    pub fn first_messages_count_for_topic(&self, topic: &TopicHash) -> Option<&BTreeMap<PeerId, u64>> {
+    pub fn first_messages_count_for_topic(
+        &self,
+        topic: &TopicHash,
+    ) -> Option<&BTreeMap<MeshIndex, u64>> {
         self.count_first_messages.get(topic)
+    }
+
+    pub fn get_mesh_index_for_topic_for_peer(
+        &self,
+        topic: &TopicHash,
+        peer_id: &PeerId,
+    ) -> Option<&MeshIndex> {
+        match self.mesh_index.get(topic) {
+            Some(mesh_indices) => mesh_indices.get(peer_id),
+            None => None,
+        }
+    }
+
+    fn update_mesh_indices_for_topic(&mut self, topic: &TopicHash) {
+        let mut remove_peers = BTreeMap::new();
+        let mut greatest_index = 0;
+        if let Some(mesh_peers) = self.mesh.get(topic) {
+            // iterate over mesh indices to find peers that have been removed from mesh
+            if let Some(mesh_indices) = self.mesh_index.get(topic) {
+                for (peer, index) in mesh_indices {
+                    if *index > greatest_index {
+                        greatest_index = index.clone();
+                    }
+                    if !mesh_peers.contains(peer) {
+                        remove_peers.insert(index.clone(), peer.clone());
+                        // zero the message counts when the peer is removed
+                        if let Some(all_count) = self.count_all_messages.get_mut(topic) {
+                            *all_count.entry(index.clone()).or_insert_with(|| 0) = 0u64;
+                        }
+                        if let Some(first_count) = self.count_first_messages.get_mut(topic) {
+                            *first_count.entry(index.clone()).or_insert_with(|| 0) = 0u64;
+                        }
+                    }
+                }
+            } else {
+                // topic isn't in mesh indices -> create it
+                self.mesh_index.insert(topic.clone(), HashMap::new());
+            }
+            // iterate over mesh and find new peers that need a peer index
+            if let Some(mesh_indices) = self.mesh_index.get_mut(topic) {
+                for mesh_peer in mesh_peers {
+                    if !mesh_indices.contains_key(mesh_peer) {
+                        let new_index: MeshIndex = match remove_peers.iter().next() {
+                            Some((rm_index, rm_peer)) => {
+                                let result = (*rm_index).clone();
+                                mesh_indices.remove(rm_peer);
+                                remove_peers.remove(&result);
+                                result
+                            }
+                            None => {
+                                greatest_index += 1;
+                                greatest_index
+                            }
+                        };
+                        mesh_indices.insert(mesh_peer.clone(), new_index);
+                    }
+                }
+            }
+        } else {
+            // we aren't subscribed to this topic anymore - zero the counts
+            if let Some(all_count) = self.count_all_messages.get_mut(topic) {
+                for (_, count) in all_count {
+                    *count = 0;
+                }
+            }
+            if let Some(first_count) = self.count_first_messages.get_mut(topic) {
+                for (_, count) in first_count {
+                    *count = 0;
+                }
+            }
+            self.mesh_index.remove(topic);
+        }
     }
 
     /// Lists all known peers and their associated protocol.
@@ -969,7 +1052,8 @@ where
                 &self.connected_peers,
             );
         }
-        debug!("Completed JOIN for topic: {:?}", topic_hash);
+        self.update_mesh_indices_for_topic(topic_hash);
+        trace!("Completed JOIN for topic: {:?}", topic_hash);
     }
 
     /// Creates a PRUNE gossipsub action.
@@ -1050,6 +1134,7 @@ where
                     &self.connected_peers,
                 );
             }
+            self.update_mesh_indices_for_topic(topic_hash);
         }
         debug!("Completed LEAVE for topic: {:?}", topic_hash);
     }
@@ -1337,6 +1422,7 @@ where
                         peer_id, &topic_hash
                     );
                     peers.insert(*peer_id);
+                    self.update_mesh_indices_for_topic(&topic_hash);
                     // If the peer did not previously exist in any mesh, inform the handler
                     peer_added_to_mesh(
                         *peer_id,
@@ -1401,7 +1487,7 @@ where
         always_update_backoff: bool,
     ) {
         let mut update_backoff = always_update_backoff;
-        if let Some(peers) = self.mesh.get_mut(&topic_hash) {
+        if let Some(peers) = self.mesh.get_mut(topic_hash) {
             // remove the peer if it exists in the mesh
             if peers.remove(peer_id) {
                 debug!(
@@ -1425,6 +1511,7 @@ where
                     &mut self.events,
                     &self.connected_peers,
                 );
+                self.update_mesh_indices_for_topic(topic_hash);
             }
         }
         if update_backoff {
@@ -1604,10 +1691,22 @@ where
         mut raw_message: RawGossipsubMessage,
         propagation_source: &PeerId,
     ) {
+        let propagation_index = match self.mesh.get(&raw_message.topic) {
+            Some(set) if set.contains(propagation_source) => self
+                .mesh_index
+                .entry(raw_message.topic.clone())
+                .or_insert_with(|| HashMap::new())
+                .get(propagation_source)
+                .map(|f| *f)
+                .unwrap_or_else(|| -2),
+            Some(_) => -3,
+            None => -4,
+        };
+
         self.count_all_messages
             .entry(raw_message.topic.clone())
             .or_insert_with(|| BTreeMap::new())
-            .entry(propagation_source.to_owned())
+            .entry(propagation_index.clone())
             .or_insert_with(|| 0)
             .add_assign(1);
 
@@ -1662,12 +1761,11 @@ where
                 peer_score.duplicated_message(propagation_source, &msg_id, &message.topic);
             }
             return;
-        }
-        else {
+        } else {
             self.count_first_messages
                 .entry(message.topic.clone())
                 .or_insert_with(|| BTreeMap::new())
-                .entry(propagation_source.to_owned())
+                .entry(propagation_index)
                 .or_insert_with(|| 0)
                 .add_assign(1)
         }
@@ -1879,9 +1977,16 @@ where
             }
         }
 
+        let mut modified_topics = topics_to_graft.iter().collect::<HashSet<_>>();
         // remove unsubscribed peers from the mesh if it exists
         for (peer_id, topic_hash) in unsubscribed_peers {
             self.remove_peer_from_mesh(&peer_id, &topic_hash, None, false);
+            // remove_peer_from_mesh will update the peer indices for us so we don't need to update it
+            modified_topics.remove(&topic_hash);
+        }
+
+        for topic in modified_topics {
+            self.update_mesh_indices_for_topic(topic);
         }
 
         // Potentially inform the handler if we have added this peer to a mesh for the first time.
@@ -1973,6 +2078,8 @@ where
             _ => 0.0,
         };
 
+        // keeps track of which topics changed in the mesh
+        let mut modified_topics = HashSet::new();
         // maintain the mesh for each topic
         for (topic_hash, peers) in self.mesh.iter_mut() {
             let explicit_peers = &self.explicit_peers;
@@ -2005,6 +2112,10 @@ where
                 })
                 .cloned()
                 .collect();
+
+            if !to_remove.is_empty() {
+                modified_topics.insert(topic_hash.clone());
+            }
             for peer in to_remove {
                 peers.remove(&peer);
             }
@@ -2038,6 +2149,7 @@ where
                 // update the mesh
                 debug!("Updating mesh, new mesh: {:?}", peer_list);
                 peers.extend(peer_list);
+                modified_topics.insert(topic_hash.clone());
             }
 
             // too many peers - remove some
@@ -2087,6 +2199,7 @@ where
 
                     // remove the peer
                     peers.remove(&peer);
+                    modified_topics.insert(topic_hash.clone());
                     let current_topic = to_prune.entry(peer).or_insert_with(Vec::new);
                     current_topic.push(topic_hash.clone());
                     removed += 1;
@@ -2121,6 +2234,7 @@ where
                     // update the mesh
                     debug!("Updating mesh, new mesh: {:?}", peer_list);
                     peers.extend(peer_list);
+                    modified_topics.insert(topic_hash.clone());
                 }
             }
 
@@ -2180,6 +2294,7 @@ where
                             topic_hash, peer_list
                         );
                         peers.extend(peer_list);
+                        modified_topics.insert(topic_hash.clone());
                     }
                 }
             }
@@ -2302,7 +2417,11 @@ where
         // shift the memcache
         self.mcache.shift();
 
-        debug!("Completed Heartbeat");
+        for topic in modified_topics {
+            self.update_mesh_indices_for_topic(&topic);
+        }
+
+        trace!("Completed Heartbeat");
     }
 
     /// Emits gossip - Send IHAVE messages to a random set of gossip peers. This is applied to mesh
@@ -2885,24 +3004,16 @@ where
 
     fn inject_disconnected(&mut self, peer_id: &PeerId) {
         // remove from mesh, topic_peers, peer_topic and the fanout
-        debug!("Peer disconnected: {}", peer_id);
-        {
-            let topics = match self.peer_topics.get(peer_id) {
-                Some(topics) => (topics),
-                None => {
-                    if !self.blacklisted_peers.contains(peer_id) {
-                        debug!("Disconnected node, not in connected nodes");
-                    }
-                    return;
-                }
-            };
-
+        info!("Peer disconnected: {}", peer_id);
+        let mut modified_topics = HashSet::new();
+        if let Some(topics) = self.peer_topics.get(peer_id) {
             // remove peer from all mappings
             for topic in topics {
                 // check the mesh for the topic
                 if let Some(mesh_peers) = self.mesh.get_mut(&topic) {
                     // check if the peer is in the mesh and remove it
                     mesh_peers.remove(peer_id);
+                    modified_topics.insert(topic.clone());
                 }
 
                 // remove from topic_peers
@@ -2926,11 +3037,20 @@ where
                     .get_mut(&topic)
                     .map(|peers| peers.remove(peer_id));
             }
-
-            //forget px and outbound status for this peer
-            self.px_peers.remove(peer_id);
-            self.outbound_peers.remove(peer_id);
+        } else {
+            if !self.blacklisted_peers.contains(peer_id) {
+                debug!("Disconnected node, not in connected nodes");
+            }
+            return;
         }
+
+        for topic in modified_topics {
+            self.update_mesh_indices_for_topic(&topic);
+        }
+
+        //forget px and outbound status for this peer
+        self.px_peers.remove(peer_id);
+        self.outbound_peers.remove(peer_id);
 
         // Remove peer from peer_topics and connected_peers
         // NOTE: It is possible the peer has already been removed from all mappings if it does not

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -242,11 +242,11 @@ impl MeshSlotMetrics {
         }
     }
 
-    pub fn with_names(&self) -> impl Iterator<Item=(&str,&u32)> {
+    pub fn with_names(&self) -> impl Iterator<Item = (&str, &u32)> {
         self.counts
             .iter()
             .enumerate()
-            .map(|(i,c)| (MESH_SLOT_METRIC_NAMES[i], c))
+            .map(|(i, c)| (MESH_SLOT_METRIC_NAMES[i], c))
     }
     pub fn churn_sum(&self) -> u32 {
         let mut result = 0;
@@ -3523,9 +3523,13 @@ where
                 NetworkBehaviourAction::ReportObservedAddr { address, score } => {
                     NetworkBehaviourAction::ReportObservedAddr { address, score }
                 }
-                NetworkBehaviourAction::CloseConnection { peer_id, connection } => {
-                    NetworkBehaviourAction::CloseConnection { peer_id, connection }
-                }
+                NetworkBehaviourAction::CloseConnection {
+                    peer_id,
+                    connection,
+                } => NetworkBehaviourAction::CloseConnection {
+                    peer_id,
+                    connection,
+                },
             });
         }
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -357,7 +357,7 @@ fn vacate_slots_of_absent_peers(
         .slot_map
         .iter()
         .filter(|(peer, ..)| !mesh_peers.contains(peer))
-        .map(|(p, s)| (p.clone(), s.clone()))
+        .map(|(p, s)| (*p, *s))
         .collect::<Vec<_>>()
     {
         if let Some(slot_metrics) = slot_data.metrics_vec.get_mut(mesh_slot) {
@@ -1081,7 +1081,7 @@ where
                 if !slot_data.slot_map.contains_key(mesh_peer) {
                     let slot = match slot_data.vacant_slots.iter().next() {
                         Some(slot_ref) => {
-                            let result = slot_ref.clone();
+                            let result = *slot_ref;
                             debug!(
                                 "metrics_event[{}]: [slot {:02}] assigning vacant slot to peer {}",
                                 topic, result, mesh_peer
@@ -1100,11 +1100,11 @@ where
                         }
                     };
                     if let Some(metrics) = slot_data.metrics_vec.get_mut(slot) {
-                        metrics.current_peer = Some(Box::new(mesh_peer.clone()));
+                        metrics.current_peer = Some(Box::new(*mesh_peer));
                     } else {
                         error!("metrics_event[{}]: [slot {:02}] assigning slot peer {} FAILURE [SlotMetrics doesn't exist in metrics vector!]", topic, slot, mesh_peer);
                     }
-                    slot_data.slot_map.insert(mesh_peer.clone(), slot);
+                    slot_data.slot_map.insert(*mesh_peer, slot);
                 }
             }
         } else {

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -554,19 +554,19 @@ where
                 for mesh_peer in mesh_peers {
                     if !index_map.contains_key(mesh_peer) {
                         let new_index: MeshIndex = match remove_peers.iter().next() {
-                            Some((rm_index, rm_peer)) => {
-                                let result = (*rm_index).clone();
-                                let lg_peer     = rm_peer.clone();
-                                index_map.remove(rm_peer);
-                                remove_peers.remove(&result);
+                            Some((index_ref, peer_ref)) => {
+                                let rm_index = index_ref.clone();
+                                let rm_peer = peer_ref.clone();
+                                remove_peers.remove(&rm_index);
+                                index_map.remove(&rm_peer);
                                 // mark this slot as churned
                                 if let Some(peer_map) = self.message_counts.get_mut(topic) {
-                                    if let Some(msg_count) = peer_map.get_mut(&result) {
-                                        debug!("churn_inspect[{}]: [index {:02}] replacing peer {} with peer {}", topic, result, lg_peer, mesh_peer);
+                                    if let Some(msg_count) = peer_map.get_mut(&rm_index) {
+                                        debug!("churn_inspect[{}]: [index {:02}] replacing peer {} with peer {}", topic, rm_index, rm_peer, mesh_peer);
                                         msg_count.churn_total.add_assign(1);
                                     }
                                 }
-                                result
+                                rm_index
                             }
                             None => {
                                 greatest_index += 1;

--- a/protocols/gossipsub/src/behaviour/slot_metrics.rs
+++ b/protocols/gossipsub/src/behaviour/slot_metrics.rs
@@ -1,0 +1,381 @@
+// Copyright 2020 Sigma Prime Pty Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use crate::TopicHash;
+use log::{debug, error, warn};
+use std::collections::{BTreeSet, HashMap};
+use std::ops::AddAssign;
+
+use libp2p_core::PeerId;
+use strum::IntoEnumIterator;
+use strum_macros::{EnumIter, IntoStaticStr};
+
+#[derive(Default)]
+pub struct SlotMetrics {
+    messages_all: u32,
+    messages_first: u32,
+    messages_ignored: u32,
+    messages_rejected: u32,
+    messages_validated: u32,
+    churn_disconnected: u32,
+    churn_excess: u32,
+    churn_leave: u32,
+    churn_prune: u32,
+    churn_score: u32,
+    churn_sum: u32,
+    churn_unknown: u32,
+    churn_unsubscribed: u32,
+    current_peer: Option<Box<PeerId>>,
+}
+
+#[derive(IntoStaticStr, EnumIter, Clone, Copy)]
+pub enum SlotMessageMetric {
+    MessagesAll,
+    MessagesFirst,
+    MessagesIgnored,
+    MessagesRejected,
+    MessagesValidated,
+}
+
+#[derive(IntoStaticStr, EnumIter, Clone, Copy)]
+pub enum SlotChurnMetric {
+    ChurnDisconnected,
+    ChurnExcess,
+    ChurnLeave,
+    ChurnPrune,
+    ChurnScore,
+    ChurnUnknown,
+    ChurnUnsubscribed,
+}
+
+pub enum SlotMetricType {
+    MessageMetric(SlotMessageMetric),
+    ChurnMetric(SlotChurnMetric),
+    ChurnSum,
+}
+
+impl SlotMetricType {
+    pub fn iter() -> impl Iterator<Item = SlotMetricType> {
+        SlotMessageMetric::iter()
+            .map(|message_metric| SlotMetricType::MessageMetric(message_metric))
+            .chain(
+                SlotChurnMetric::iter()
+                    .map(|churn_metric| SlotMetricType::ChurnMetric(churn_metric)),
+            )
+            .chain(std::iter::once(SlotMetricType::ChurnSum))
+    }
+}
+
+impl SlotMetrics {
+    #[inline]
+    fn get_message_metric(&self, message_metric: SlotMessageMetric) -> u32 {
+        match message_metric {
+            SlotMessageMetric::MessagesAll => self.messages_all,
+            SlotMessageMetric::MessagesFirst => self.messages_first,
+            SlotMessageMetric::MessagesIgnored => self.messages_ignored,
+            SlotMessageMetric::MessagesRejected => self.messages_rejected,
+            SlotMessageMetric::MessagesValidated => self.messages_validated,
+        }
+    }
+
+    #[inline]
+    fn increment_message_metric(&mut self, message_metric: SlotMessageMetric) {
+        match message_metric {
+            SlotMessageMetric::MessagesAll => self.messages_all.add_assign(1),
+            SlotMessageMetric::MessagesFirst => self.messages_first.add_assign(1),
+            SlotMessageMetric::MessagesIgnored => self.messages_ignored.add_assign(1),
+            SlotMessageMetric::MessagesRejected => self.messages_rejected.add_assign(1),
+            SlotMessageMetric::MessagesValidated => self.messages_validated.add_assign(1),
+        };
+    }
+
+    #[inline]
+    fn get_churn_metric(&self, churn_reason: SlotChurnMetric) -> u32 {
+        match churn_reason {
+            SlotChurnMetric::ChurnDisconnected => self.churn_disconnected,
+            SlotChurnMetric::ChurnExcess => self.churn_excess,
+            SlotChurnMetric::ChurnLeave => self.churn_leave,
+            SlotChurnMetric::ChurnPrune => self.churn_prune,
+            SlotChurnMetric::ChurnScore => self.churn_score,
+            SlotChurnMetric::ChurnUnknown => self.churn_unknown,
+            SlotChurnMetric::ChurnUnsubscribed => self.churn_unsubscribed,
+        }
+    }
+
+    pub fn churn_slot(&mut self, churn_reason: SlotChurnMetric) {
+        self.current_peer = None;
+        self.churn_sum.add_assign(1);
+        match churn_reason {
+            SlotChurnMetric::ChurnDisconnected => self.churn_disconnected.add_assign(1),
+            SlotChurnMetric::ChurnExcess => self.churn_excess.add_assign(1),
+            SlotChurnMetric::ChurnLeave => self.churn_leave.add_assign(1),
+            SlotChurnMetric::ChurnPrune => self.churn_prune.add_assign(1),
+            SlotChurnMetric::ChurnScore => self.churn_score.add_assign(1),
+            SlotChurnMetric::ChurnUnknown => self.churn_unknown.add_assign(1),
+            SlotChurnMetric::ChurnUnsubscribed => self.churn_unsubscribed.add_assign(1),
+        };
+    }
+
+    pub fn current_peer(&self) -> &Option<Box<PeerId>> {
+        &self.current_peer
+    }
+
+    pub fn assign_slot(&mut self, peer: PeerId) {
+        self.current_peer = Some(Box::new(peer));
+    }
+
+    pub fn get_slot_metric(&self, metric_type: SlotMetricType) -> u32 {
+        match metric_type {
+            SlotMetricType::MessageMetric(message_metric) => {
+                self.get_message_metric(message_metric)
+            }
+            SlotMetricType::ChurnMetric(churn_reason) => self.get_churn_metric(churn_reason),
+            SlotMetricType::ChurnSum => self.churn_sum,
+        }
+    }
+
+    pub fn type_iter() -> impl Iterator<Item = SlotMetricType> {
+        SlotMetricType::iter()
+    }
+
+    pub fn with_names(&self) -> Vec<(&'static str, u32)> {
+        SlotMetricType::iter()
+            .map(|t| match t {
+                SlotMetricType::MessageMetric(message_metric) => (
+                    <SlotMessageMetric as Into<&'static str>>::into(message_metric),
+                    self.get_message_metric(message_metric),
+                ),
+                SlotMetricType::ChurnMetric(churn_reason) => (
+                    <SlotChurnMetric as Into<&'static str>>::into(churn_reason),
+                    self.get_churn_metric(churn_reason),
+                ),
+                SlotMetricType::ChurnSum => ("ChurnSum", self.churn_sum),
+            })
+            .collect()
+    }
+
+    pub fn new() -> Self {
+        SlotMetrics::default()
+    }
+}
+
+pub type MeshSlot = usize;
+pub struct MeshSlotData {
+    /// The topic this MeshSlotData belongs to (useful for debugging)
+    topic: TopicHash,
+    /// Vector of SlotMetrics (vector indexed by MeshSlot)
+    metrics_vec: Vec<SlotMetrics>,
+    /// Map of PeerId to MeshSlot
+    slot_map: HashMap<PeerId, MeshSlot>,
+    /// Set of Vacant MeshSlots (due to peers leaving the mesh)
+    vacant_slots: BTreeSet<MeshSlot>,
+}
+
+impl MeshSlotData {
+    pub fn new(topic: TopicHash) -> Self {
+        MeshSlotData {
+            topic,
+            // the first element in the vector is for peers that aren't in the mesh
+            metrics_vec: vec![SlotMetrics::new()],
+            slot_map: HashMap::new(),
+            vacant_slots: BTreeSet::new(),
+        }
+    }
+
+    /// Increments the message metric for the specified peer
+    pub fn increment_message_metric(&mut self, peer: &PeerId, message_metric: SlotMessageMetric) {
+        let slot = self
+            .slot_map
+            .get(peer)
+            .map(|s| *s)
+            // peers that aren't in the mesh get slot 0
+            .unwrap_or(0);
+        match self
+            .metrics_vec
+            .get_mut(slot)
+        {
+            Some(slot_metrics) => slot_metrics.increment_message_metric(message_metric),
+            None => error!(
+                "metrics_event[{}]: [slot {:02}] increment {} peer {} FAILURE [mesh_slots contains peer with slot not existing in mesh_slot_metrics!]",
+                self.topic,
+                slot,
+                <SlotMessageMetric as Into<&'static str>>::into(message_metric),
+                peer,
+            ),
+        };
+    }
+
+    /// Assigns a slot to the peer if the peer doesn't already have one.
+    pub fn assign_slot_if_unassigned(&mut self, peer: PeerId) {
+        if !self.slot_map.contains_key(&peer) {
+            match self.vacant_slots.iter().next() {
+                Some(slot_ref) => match self.metrics_vec.get_mut(*slot_ref) {
+                    Some(slot_metrics) => {
+                        let slot = *slot_ref;
+                        debug!(
+                            "metrics_event[{}]: [slot {:02}] assigning vacant slot to peer {} SUCCESS",
+                                self.topic, slot, peer
+                        );
+                        slot_metrics.assign_slot(peer.clone());
+                        self.vacant_slots.remove(&slot);
+                        self.slot_map.insert(peer, slot);
+                    },
+                    None => error!(
+                        "metrics_event[{}]: [slot {:02}] assigning vacant slot to peer {} FAILURE [SlotMetrics doesn't exist in metrics vector!]",
+                        self.topic, slot_ref, peer
+                    ),
+                },
+                None => {
+                    let slot = self.metrics_vec.len();
+                    debug!(
+                        "metrics_event[{}]: [slot {:02}] assigning new slot to peer {} SUCCESS",
+                            self.topic, slot, peer
+                    );
+                    let mut slot_metrics = SlotMetrics::new();
+                    slot_metrics.assign_slot(peer.clone());
+                    self.metrics_vec.push(slot_metrics);
+                    self.slot_map.insert(peer, slot);
+                }
+            };
+        }
+    }
+
+    pub fn assign_slots_to_peers<U>(&mut self, peer_iter: U)
+    where
+        U: Iterator<Item = PeerId>,
+    {
+        for peer in peer_iter {
+            self.assign_slot_if_unassigned(peer);
+        }
+    }
+
+    /// Churns the slot occupied by peer.
+    pub fn churn_slot(&mut self, peer: &PeerId, churn_reason: SlotChurnMetric) {
+        match self.slot_map.get(peer).cloned() {
+            Some(slot) => match self.metrics_vec.get_mut(slot) {
+                Some(slot_metrics) => {
+                    debug_assert!(!self.vacant_slots.contains(&slot),
+                        "metrics_event[{}] [slot {:02}] increment {} peer {} FAILURE [vacant slots already contains this slot!]",
+                            self.topic, slot, <SlotChurnMetric as Into<&'static str>>::into(churn_reason), peer
+                    );
+                    slot_metrics.churn_slot(churn_reason);
+                    self.vacant_slots.insert(slot);
+                    self.slot_map.remove(peer);
+                    debug!(
+                        "metrics_event[{}]: [slot {:02}] increment {} peer {} SUCCESS",
+                            self.topic, slot, <SlotChurnMetric as Into<&'static str>>::into(churn_reason), peer
+                    );
+                },
+                None => warn!(
+                    "metrics_event[{}]: [slot {:02}] increment {} peer {} FAILURE [retrieving slot_metrics]",
+                        self.topic, slot, <SlotChurnMetric as Into<&'static str>>::into(churn_reason), peer
+                ),
+            },
+            None => warn!(
+                "metrics_event[{}]: [slot --] increment {} peer {} FAILURE [retrieving slot]",
+                    self.topic, <SlotChurnMetric as Into<&'static str>>::into(churn_reason), peer
+            ),
+        };
+    }
+
+    /// Churns all slots in this topic that aren't already vacant (while incrementing
+    /// churn_reason). Also clears the slot_map. This loop is faster than doing this individually
+    /// for each peer in the topic because it minimizes redundant lookups and only traverses
+    /// a vector.
+    pub fn churn_all_slots(&mut self, churn_reason: SlotChurnMetric) {
+        for slot in (1..self.metrics_vec.len())
+            .filter(|s| !self.vacant_slots.contains(s))
+            .collect::<Vec<_>>()
+        {
+            match self.metrics_vec.get_mut(slot) {
+                Some(slot_metrics) => {
+                    match slot_metrics.current_peer() {
+                        Some(peer) => debug!(
+                            "metrics_event[{}]: [slot {:02}] increment {} peer {} SUCCESS",
+                                self.topic, slot, <SlotChurnMetric as Into<&'static str>>::into(churn_reason), peer
+                        ),
+                        None => warn!(
+                            "metrics_event[{}]: [slot {:02}] increment {} WARNING [current_peer not assigned with non-vacant slot!]",
+                                self.topic, slot, <SlotChurnMetric as Into<&'static str>>::into(churn_reason),
+                        ),
+                    };
+                    slot_metrics.churn_slot(churn_reason);
+                    self.vacant_slots.insert(slot);
+                },
+                None => error!(
+                    "metrics_event[{}]: [slot {:02}] increment {} FAILURE [mesh_slots contains peer with slot not existing in mesh_slot_metrics!]",
+                    self.topic, slot, <SlotChurnMetric as Into<&'static str>>::into(churn_reason),
+                ),
+            };
+        }
+        self.slot_map.clear();
+    }
+
+    /// This function verifies that the MeshSlotData is synchronized perfectly with the mesh:
+    pub fn verify_mesh_slots(&self, mesh: &BTreeSet<PeerId>) -> Result<(), String> {
+        let mut result = true;
+        let mut errors = String::new();
+        // No peers are in the slot_map that aren't in the mesh
+        for (peer, slot) in self
+            .slot_map
+            .iter()
+            .filter(|(peer, ..)| !mesh.contains(peer))
+        {
+            result = false;
+            let message = format!(
+                "metrics_event[{}]: [slot {:02}] peer {} exists in slot_map but not in the mesh!\n",
+                self.topic, slot, peer
+            );
+            errors.push_str(message.as_str());
+            error!("{}", message);
+        }
+        // No peers are in the mesh that aren't in the slot_map
+        for peer in mesh.iter().filter(|peer| !self.slot_map.contains_key(peer)) {
+            result = false;
+            let message = format!(
+                "metrics_event[{}]: [slot --] peer {} exists in mesh but not in the slot_map!\n",
+                self.topic, peer
+            );
+            errors.push_str(message.as_str());
+            error!("{}", message);
+        }
+
+        // vacant_slots.len() + slot_map.len() == metrics_vec.len() + 1
+        if self.vacant_slots.len() + self.slot_map.len() != self.metrics_vec.len() + 1 {
+            result = false;
+            let message = format!(
+                "metrics_event[{}] vacant_slots.len()[{}] + slot_map.len()[{}] != metrics_vec.len()[{}] + 1",
+                    self.topic, self.vacant_slots.len(), self.slot_map.len(), self.metrics_vec.len(),
+            );
+            errors.push_str(message.as_str());
+            error!("{}", message);
+        }
+
+        if result {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    pub fn slot_iter(&self) -> impl Iterator<Item = &SlotMetrics> {
+        self.metrics_vec.iter()
+    }
+}

--- a/protocols/gossipsub/src/behaviour/slot_metrics.rs
+++ b/protocols/gossipsub/src/behaviour/slot_metrics.rs
@@ -328,7 +328,9 @@ impl MeshSlotData {
         self.slot_map.clear();
     }
 
-    /// This function verifies that the MeshSlotData is synchronized perfectly with the mesh
+    /// This function verifies that the MeshSlotData is synchronized perfectly with the mesh.
+    /// It's useful for debugging.
+    #[allow(dead_code)]
     pub fn validate_mesh_slots(&self, mesh: &BTreeSet<PeerId>) -> Result<(), String> {
         let mut result = true;
         let mut errors = String::new();

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -213,6 +213,10 @@ impl PeerScore {
 
     /// Returns the score for a peer.
     pub fn score(&self, peer_id: &PeerId) -> f64 {
+        self.score_with_index(peer_id, None)
+    }
+
+    pub fn score_with_index(&self, peer_id: &PeerId, slot_index: Option<i32>) -> f64 {
         let peer_stats = match self.peer_stats.get(peer_id) {
             Some(v) => v,
             None => return 0.0,
@@ -264,9 +268,13 @@ impl PeerScore {
                     let p3 = deficit * deficit;
                     topic_score += p3 * topic_params.mesh_message_deliveries_weight;
                     debug!(
-                        "The peer {} has a mesh message deliveries deficit of {} in topic\
+                        "SCORE_PENALTY: The peer {} (mesh index [{}]) has a mesh message deliveries deficit of {} in topic\
                          {} and will get penalized by {}",
                         peer_id,
+                        match &slot_index {
+                            Some(id) => i32::to_string(id),
+                            None => "unknown".to_string(),
+                        },
                         deficit,
                         topic,
                         p3 * topic_params.mesh_message_deliveries_weight

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -213,10 +213,6 @@ impl PeerScore {
 
     /// Returns the score for a peer.
     pub fn score(&self, peer_id: &PeerId) -> f64 {
-        self.score_with_index(peer_id, None)
-    }
-
-    pub fn score_with_index(&self, peer_id: &PeerId, slot_index: Option<i32>) -> f64 {
         let peer_stats = match self.peer_stats.get(peer_id) {
             Some(v) => v,
             None => return 0.0,
@@ -268,13 +264,9 @@ impl PeerScore {
                     let p3 = deficit * deficit;
                     topic_score += p3 * topic_params.mesh_message_deliveries_weight;
                     debug!(
-                        "SCORE_PENALTY: The peer {} (mesh index [{}]) has a mesh message deliveries deficit of {} in topic\
+                        "SCORE_PENALTY: The peer {} has a mesh message deliveries deficit of {} in topic\
                          {} and will get penalized by {}",
                         peer_id,
-                        match &slot_index {
-                            Some(id) => i32::to_string(id),
-                            None => "unknown".to_string(),
-                        },
                         deficit,
                         topic,
                         p3 * topic_params.mesh_message_deliveries_weight

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -264,7 +264,7 @@ impl PeerScore {
                     let p3 = deficit * deficit;
                     topic_score += p3 * topic_params.mesh_message_deliveries_weight;
                     debug!(
-                        "SCORE_PENALTY: The peer {} has a mesh message deliveries deficit of {} in topic\
+                        "The peer {} has a mesh message deliveries deficit of {} in topic\
                          {} and will get penalized by {}",
                         peer_id,
                         deficit,


### PR DESCRIPTION
We now have counters for a ton of different metrics allowing us a lot of visibility into how often messages are coming in. This should allow us to tune the gossipsub scoring parameters much easier and detect attacks. In addition to that, we have an event log for what the set of peers in a given topic looks like. This is about as fast as I can make this. Given a topic, a peer, and a metric, it takes two HashMap lookups to locate the proper metric and increment it.