### PR TITLE
Cleanup code & Remove Redundant map Lookups

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -769,14 +769,11 @@ where
 
                 // Metrics: Report validation result
                 #[cfg(feature = "metrics")]
-                self.metrics
-                    .mesh_slot_data
-                    .entry(raw_message.topic.clone())
-                    .or_insert_with(|| MeshSlotData::new(raw_message.topic.clone()))
-                    .increment_message_metric(
-                        propagation_source,
-                        SlotMessageMetric::MessagesValidated,
-                    );
+                self.metrics.increment_message_metric(
+                    &raw_message.topic,
+                    propagation_source,
+                    SlotMessageMetric::MessagesValidated,
+                );
                 return Ok(true);
             }
             MessageAcceptance::Reject => {
@@ -784,14 +781,11 @@ where
                 #[cfg(feature = "metrics")]
                 if let Some(raw_message) = self.mcache.get(msg_id) {
                     // Increment metrics
-                    self.metrics
-                        .mesh_slot_data
-                        .entry(raw_message.topic.clone())
-                        .or_insert_with(|| MeshSlotData::new(raw_message.topic.clone()))
-                        .increment_message_metric(
-                            propagation_source,
-                            SlotMessageMetric::MessagesRejected,
-                        );
+                    self.metrics.increment_message_metric(
+                        &raw_message.topic,
+                        propagation_source,
+                        SlotMessageMetric::MessagesRejected,
+                    );
                 }
                 RejectReason::ValidationFailed
             }
@@ -800,14 +794,11 @@ where
                 #[cfg(feature = "metrics")]
                 if let Some(raw_message) = self.mcache.get(msg_id) {
                     // Increment metrics
-                    self.metrics
-                        .mesh_slot_data
-                        .entry(raw_message.topic.clone())
-                        .or_insert_with(|| MeshSlotData::new(raw_message.topic.clone()))
-                        .increment_message_metric(
-                            propagation_source,
-                            SlotMessageMetric::MessagesIgnored,
-                        );
+                    self.metrics.increment_message_metric(
+                        &raw_message.topic,
+                        propagation_source,
+                        SlotMessageMetric::MessagesIgnored,
+                    );
                 }
                 RejectReason::ValidationIgnored
             }
@@ -1015,10 +1006,7 @@ where
 
         #[cfg(feature = "metrics")]
         self.metrics
-            .mesh_slot_data
-            .entry(topic_hash.clone())
-            .or_insert_with(|| MeshSlotData::new(topic_hash.clone()))
-            .assign_slots_to_peers(added_peers.iter().cloned());
+            .assign_slots_to_peers(topic_hash, added_peers.iter().cloned());
 
         for peer_id in added_peers {
             // Send a GRAFT control message
@@ -1446,11 +1434,7 @@ where
                     peers.insert(*peer_id);
 
                     #[cfg(feature = "metrics")]
-                    self.metrics
-                        .mesh_slot_data
-                        .entry(topic_hash.clone())
-                        .or_insert_with(|| MeshSlotData::new(topic_hash.clone()))
-                        .assign_slot_if_unassigned(*peer_id);
+                    self.metrics.assign_slot_if_unassigned(&topic_hash, peer_id);
 
                     // If the peer did not previously exist in any mesh, inform the handler
                     peer_added_to_mesh(
@@ -1514,8 +1498,7 @@ where
         topic_hash: &TopicHash,
         backoff: Option<u64>,
         always_update_backoff: bool,
-        #[cfg(feature = "metrics")]
-        churn_reason: SlotChurnMetric,
+        #[cfg(feature = "metrics")] churn_reason: SlotChurnMetric,
     ) {
         let mut update_backoff = always_update_backoff;
         if let Some(peers) = self.mesh.get_mut(topic_hash) {
@@ -1734,11 +1717,11 @@ where
         // ignore it.
         #[cfg(feature = "metrics")]
         if self.mesh.contains_key(&raw_message.topic) {
-            self.metrics
-                .mesh_slot_data
-                .entry(raw_message.topic.clone())
-                .or_insert_with(|| MeshSlotData::new(raw_message.topic.clone()))
-                .increment_message_metric(propagation_source, SlotMessageMetric::MessagesAll);
+            self.metrics.increment_message_metric(
+                &raw_message.topic,
+                propagation_source,
+                SlotMessageMetric::MessagesAll,
+            );
         }
 
         let fast_message_id = self.config.fast_message_id(&raw_message);
@@ -1826,11 +1809,11 @@ where
         // Increment the first message topic, if its in our mesh.
         #[cfg(feature = "metrics")]
         if self.mesh.contains_key(&raw_message.topic) {
-            self.metrics
-                .mesh_slot_data
-                .entry(raw_message.topic.clone())
-                .or_insert_with(|| MeshSlotData::new(raw_message.topic.clone()))
-                .increment_message_metric(propagation_source, SlotMessageMetric::MessagesFirst);
+            self.metrics.increment_message_metric(
+                &raw_message.topic,
+                propagation_source,
+                SlotMessageMetric::MessagesFirst,
+            );
         }
 
         // Tells score that message arrived (but is maybe not fully validated yet).
@@ -2069,10 +2052,7 @@ where
         #[cfg(feature = "metrics")]
         for topic in &topics_to_graft {
             self.metrics
-                .mesh_slot_data
-                .entry(topic.clone())
-                .or_insert_with(|| MeshSlotData::new(topic.clone()))
-                .assign_slot_if_unassigned(*propagation_source);
+                .assign_slot_if_unassigned(topic, propagation_source);
         }
 
         // If we need to send grafts to peer, do so immediately, rather than waiting for the
@@ -2165,6 +2145,12 @@ where
             let backoffs = &self.backoffs;
             let topic_peers = &self.topic_peers;
             let outbound_peers = &self.outbound_peers;
+            #[cfg(feature = "metrics")]
+            let slot_data = self
+                .metrics
+                .mesh_slot_data
+                .entry(topic_hash.clone())
+                .or_insert_with(|| MeshSlotData::new(topic_hash.clone()));
 
             // drop all peers with negative score, without PX
             // if there is at some point a stable retain method for BTreeSet the following can be
@@ -2196,8 +2182,7 @@ where
 
                 // Increment ChurnScore and remove peer from slot
                 #[cfg(feature = "metrics")]
-                self.metrics
-                    .churn_slot(&topic_hash, &peer, SlotChurnMetric::ChurnScore);
+                slot_data.churn_slot(&peer, SlotChurnMetric::ChurnScore);
                 #[cfg(all(debug_assertions, feature = "metrics"))]
                 modified_topics.insert(topic_hash.clone());
             }
@@ -2234,8 +2219,7 @@ where
 
                     // Metrics: Update mesh peers
                     #[cfg(feature = "metrics")]
-                    self.metrics
-                        .assign_slots_to_peers(topic_hash, peer_list.iter().cloned());
+                    slot_data.assign_slots_to_peers(peer_list.iter().cloned());
                     #[cfg(all(debug_assertions, feature = "metrics"))]
                     modified_topics.insert(topic_hash.clone());
 
@@ -2293,8 +2277,7 @@ where
                     }
                     // Metrics: increment ChurnExcess and vacate slot
                     #[cfg(feature = "metrics")]
-                    self.metrics
-                        .churn_slot(topic_hash, &peer, SlotChurnMetric::ChurnExcess);
+                    slot_data.churn_slot(&peer, SlotChurnMetric::ChurnExcess);
                     #[cfg(all(debug_assertions, feature = "metrics"))]
                     modified_topics.insert(topic_hash.clone());
 
@@ -2336,8 +2319,7 @@ where
                         trace!("Updating mesh, adding to mesh: {:?}", peer_list);
 
                         #[cfg(feature = "metrics")]
-                        self.metrics
-                            .assign_slots_to_peers(topic_hash, peer_list.iter().cloned());
+                        slot_data.assign_slots_to_peers(peer_list.iter().cloned());
                         #[cfg(all(debug_assertions, feature = "metrics"))]
                         modified_topics.insert(topic_hash.clone());
 
@@ -2407,8 +2389,7 @@ where
 
                             // Metrics: Update mesh peers
                             #[cfg(feature = "metrics")]
-                            self.metrics
-                                .assign_slots_to_peers(topic_hash, peer_list.iter().cloned());
+                            slot_data.assign_slots_to_peers(peer_list.iter().cloned());
                             #[cfg(all(debug_assertions, feature = "metrics"))]
                             modified_topics.insert(topic_hash.clone());
 

--- a/protocols/gossipsub/src/metrics.rs
+++ b/protocols/gossipsub/src/metrics.rs
@@ -59,6 +59,7 @@ impl Default for InternalMetrics {
             broken_promises: 0,
             iwant_requests: 0,
             memcache_misses: 0,
+            messages_received_on_invalid_topic: 0,
             duplicates_filtered: HashMap::new(),
         }
     }
@@ -87,12 +88,10 @@ impl InternalMetrics {
     ) {
         match self.mesh_slot_data.get_mut(topic) {
             Some(slot_data) => slot_data.churn_slot(peer_id, churn_reason),
-            None => {
-                warn!(
+            None => warn!(
                 "metrics_event[{}]: [slot --] increment {} peer {} FAILURE [retrieving slot_data]",
                 topic, <SlotChurnMetric as Into<&'static str>>::into(churn_reason), peer_id,
             )
-            }
         }
     }
 


### PR DESCRIPTION
There are 3 primary changes here:

1. The `churn_reason` arg has been added back to `remove_peer_from_mesh()`, though it's now behind the feature flag. This removes an unnecessary redundant lookup to see if the peer is in the mesh and (IMO) makes the code simpler.
2. I've increased the frequency of calling methods on the `InternalMetrics` struct instead of manipulating its members. It looks cleaner now.
3. As an exception to the above, I opted out of calling methods on the `InternalMetrics` in the `heartbeat()` function. By storing a reference to the `MeshSlotData` and interacting with that, you can eliminate up to 4 redundant map lookups per iteration of the main loop over topics. That should be a good cumulative timesave considering this is the heartbeat function.