### PR TITLE
Replace EncoderMetrics with SendSyncEncodeMetric

### DIFF
--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -32,7 +32,8 @@ wasm-timer = "0.2.5"
 instant = "0.1.11"
 # Metrics dependencies
 # TODO: Change to v0.19 once the version has been released.
-prometheus-client = { git = "https://github.com/ackintosh/client_rust.git", rev = "5e145bb0cb52ab4ff01c862a6117fb61ee107f17", features = ["protobuf"] }
+# See https://github.com/prometheus/client_rust/pull/99
+prometheus-client = { git = "https://github.com/ackintosh/client_rust.git", rev = "f6450001d564d4ce260a56e959f05638999fe9d8", features = ["protobuf"] }
 
 [dev-dependencies]
 async-std = "1.6.3"

--- a/protocols/gossipsub/src/metrics.rs
+++ b/protocols/gossipsub/src/metrics.rs
@@ -99,8 +99,8 @@ impl Default for Config {
 /// Whether we have ever been subscribed to this topic.
 type EverSubscribed = bool;
 
-pub type TextEncoder = Box<dyn prometheus_client::encoding::text::EncodeMetric>;
-pub type ProtoEncoder = Box<dyn prometheus_client::encoding::proto::EncodeMetric>;
+pub type TextEncoder = Box<dyn prometheus_client::encoding::text::SendSyncEncodeMetric>;
+pub type ProtoEncoder = Box<dyn prometheus_client::encoding::proto::SendSyncEncodeMetric>;
 pub trait AnyEncoder: Sized {
     fn new_metrics(registry: &mut Registry<Self>, config: Config) -> Metrics<Self>;
 }


### PR DESCRIPTION
in order to allow the encoders to be used in async tasks.

FYI: `proto::SendSyncEncodeMetric` is not in master branch yet. ( https://github.com/prometheus/client_rust/pull/99 )

