### PR TITLE
Couple the send_queue more closely with connected peers

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -5,8 +5,6 @@
 
 - Removes the control pool and sends control messages on demand.
 
-- Implement publish and forward message dropping.
-
 - Implement backpressure by differentiating between priority and non priority messages.
   Drop `Publish` and `Forward` messages when the queue becomes full.
   See [PR 4914](https://github.com/libp2p/rust-libp2p/pull/4914)

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -176,6 +176,12 @@ impl Handler {
 }
 
 impl EnabledHandler {
+    #[cfg(test)]
+    /// For testing purposed obtain the RPCReceiver
+    pub fn receiver(&mut self) -> RpcReceiver {
+        self.send_queue.clone()
+    }
+
     fn on_fully_negotiated_inbound(
         &mut self,
         (substream, peer_kind): (Framed<Stream, GossipsubCodec>, PeerKind),

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -109,12 +109,23 @@ impl std::fmt::Debug for MessageId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub(crate) struct PeerConnections {
     /// The kind of protocol the peer supports.
     pub(crate) kind: PeerKind,
     /// Its current connections.
     pub(crate) connections: Vec<ConnectionId>,
+    /// The send queue handler for each connection id.
+    pub(crate) handler_send_queue: Vec<RpcSender>,
+}
+
+impl PeerConnections {
+    /// Obtains the first send queue handler.
+    pub(crate) fn send_queue(&mut self) -> &mut RpcSender {
+        self.handler_send_queue
+            .first_mut()
+            .expect("There is always at least one handler send queue")
+    }
 }
 
 /// Describes the types of peers that can exist in the gossipsub context.

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -115,17 +115,8 @@ pub(crate) struct PeerConnections {
     pub(crate) kind: PeerKind,
     /// Its current connections.
     pub(crate) connections: Vec<ConnectionId>,
-    /// The send queue handler for each connection id.
-    pub(crate) handler_send_queue: Vec<RpcSender>,
-}
-
-impl PeerConnections {
-    /// Obtains the first send queue handler.
-    pub(crate) fn send_queue(&mut self) -> &mut RpcSender {
-        self.handler_send_queue
-            .first_mut()
-            .expect("There is always at least one handler send queue")
-    }
+    /// The rpc sender to the peer.
+    pub(crate) sender: RpcSender,
 }
 
 /// Describes the types of peers that can exist in the gossipsub context.
@@ -644,19 +635,19 @@ impl RpcSender {
     }
 
     /// Send a `RpcOut::IHave` message to the `RpcReceiver`
-    /// this is low priority and if queue is full the message is dropped.
-    pub(crate) fn ihave(&mut self, ihave: IHave) -> Result<(), ()> {
+    /// this is low priority, if the queue is full an Err is returned.
+    pub(crate) fn ihave(&mut self, ihave: IHave) -> Result<(), RpcOut> {
         self.non_priority
             .try_send(RpcOut::IHave(ihave))
-            .map_err(|_| ())
+            .map_err(|err| err.into_inner())
     }
 
     /// Send a `RpcOut::IHave` message to the `RpcReceiver`
-    /// this is low priority and if queue is full the message is dropped.
-    pub(crate) fn iwant(&mut self, iwant: IWant) -> Result<(), ()> {
+    /// this is low priority, if the queue is full an Err is returned.
+    pub(crate) fn iwant(&mut self, iwant: IWant) -> Result<(), RpcOut> {
         self.non_priority
             .try_send(RpcOut::IWant(iwant))
-            .map_err(|_| ())
+            .map_err(|err| err.into_inner())
     }
 
     /// Send a `RpcOut::Subscribe` message to the `RpcReceiver`


### PR DESCRIPTION
It is difficult to reason about handler send queues and if in fact they are always in sync with the connected_peer mappings. 

This shifts the send-queues inside the connected_peers mapping to ensure that if there is a connected peer, then it should have a send_queue. 

This prevents any kind of panics that may arise if the send-queue mapping is out of sync with the connected peer mapping. There may still be panics if the connected_peer list is out of sync with mesh or topic mappings, however that is out of scope of this PR. 

As gossipsub has been running for a while, we assume the above mappings are correct.