### PR TITLE
feat(gossipsub): use connected_peers instead of handler_send_queues 

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -5,8 +5,6 @@
 
 - Removes the control pool and sends control messages on demand.
 
-- Implement publish and forward message dropping.
-
 - Implement backpressure by differentiating between priority and non priority messages.
   Drop `Publish` and `Forward` messages when the queue becomes full.
   See [PR 4914](https://github.com/libp2p/rust-libp2p/pull/4914)

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -109,12 +109,14 @@ impl std::fmt::Debug for MessageId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub(crate) struct PeerConnections {
     /// The kind of protocol the peer supports.
     pub(crate) kind: PeerKind,
     /// Its current connections.
     pub(crate) connections: Vec<ConnectionId>,
+    /// The rpc sender to the peer.
+    pub(crate) sender: RpcSender,
 }
 
 /// Describes the types of peers that can exist in the gossipsub context.
@@ -633,19 +635,19 @@ impl RpcSender {
     }
 
     /// Send a `RpcOut::IHave` message to the `RpcReceiver`
-    /// this is low priority and if queue is full the message is dropped.
-    pub(crate) fn ihave(&mut self, ihave: IHave) -> Result<(), ()> {
+    /// this is low priority, if the queue is full an Err is returned.
+    pub(crate) fn ihave(&mut self, ihave: IHave) -> Result<(), RpcOut> {
         self.non_priority
             .try_send(RpcOut::IHave(ihave))
-            .map_err(|_| ())
+            .map_err(|err| err.into_inner())
     }
 
     /// Send a `RpcOut::IHave` message to the `RpcReceiver`
-    /// this is low priority and if queue is full the message is dropped.
-    pub(crate) fn iwant(&mut self, iwant: IWant) -> Result<(), ()> {
+    /// this is low priority, if the queue is full an Err is returned.
+    pub(crate) fn iwant(&mut self, iwant: IWant) -> Result<(), RpcOut> {
         self.non_priority
             .try_send(RpcOut::IWant(iwant))
-            .map_err(|_| ())
+            .map_err(|err| err.into_inner())
     }
 
     /// Send a `RpcOut::Subscribe` message to the `RpcReceiver`


### PR DESCRIPTION
to avoid extra redundancy. 

allow peer retrieval to be fallible when forwarding and publishing messages as peer might still exist in the mesh and explicit peers but is no longer connected. 

superseeds  #561 

## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
